### PR TITLE
fix(keys): emit runtime keys.js so ESM consumers can import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",
@@ -11,13 +11,13 @@
     },
     "./keys": {
       "types": "./dist/keys.d.ts",
-      "import": "./src/keys.ts",
-      "default": "./src/keys.ts"
+      "import": "./dist/keys.js",
+      "default": "./dist/keys.js"
     }
   },
   "files": ["dist", "src/keys.ts"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.keys.json",
     "clean": "rm -rf dist",
     "sync:from-host": "node scripts/sync-from-host.mjs",
     "check:drift": "node scripts/sync-from-host.mjs --check"

--- a/tsconfig.keys.json
+++ b/tsconfig.keys.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "declaration": false,
+    "declarationMap": false,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist"
+  },
+  "include": ["src/keys.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- `./keys` subpath export pointed `import`/`default` at `src/keys.ts`; Node ESM cannot load TS at runtime.
- `emitDeclarationOnly` in `tsconfig.json` meant no `.js` was ever emitted for `keys.ts`, so `@lvis/plugin-sdk/keys` was unresolvable at runtime.
- This surfaced as 3 pre-existing vitest failures on `lvis-app` main (flagged by E4).

## Fix
- Add `tsconfig.keys.json` that compiles `src/keys.ts` with JS emission (index.ts remains type-only).
- Chain `tsc -p tsconfig.keys.json` after the types build.
- Repoint `./keys` export `import`/`default` -> `./dist/keys.js`.
- Bump patch version `1.0.2` -> `1.0.3`.

## Test plan
- [x] `npm run build` produces `dist/keys.js` and `dist/keys.d.ts`.
- [x] `node --input-type=module -e "import { MARKETPLACE_PRIMARY_KEY_ID } from './dist/keys.js'; console.log(MARKETPLACE_PRIMARY_KEY_ID)"` prints `poc-v1`.
- [ ] Downstream `lvis-app` vitest runs clean after resync.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>