### PR TITLE
feat(types): sync triggerConversation + ConversationTriggerSpec/Result from host

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,10 +1,15 @@
 name: drift-check
 on:
+  pull_request:
+    paths:
+      - 'src/index.ts'
+      - 'scripts/sync-from-host.mjs'
+      - '.github/workflows/drift-check.yml'
   schedule:
     - cron: '17 3 * * *'   # nightly ~03:17 UTC
   workflow_dispatch: {}
 concurrency:
-  group: drift-check
+  group: drift-check-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check:
@@ -54,8 +59,14 @@ jobs:
           else
             echo "drift=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Fail on drift (PR mode)
+        if: github.event_name == 'pull_request' && steps.diff.outputs.drift == 'true'
+        run: |
+          echo "::error::Drift detected between src/index.ts and host types.ts. Run 'bun run sync:from-host' locally and commit the result."
+          git --no-pager diff -- src/index.ts | head -200
+          exit 1
       - name: Open PR on drift
-        if: steps.diff.outputs.drift == 'true'
+        if: github.event_name != 'pull_request' && steps.diff.outputs.drift == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +81,7 @@ jobs:
           base: main
           delete-branch: true
       - name: Open issue on workflow failure
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@lvis/plugin-sdk",
       "devDependencies": {
         "typescript": "^6.0.3",
-        "vitest": "^4.1.4",
+        "vitest": "^4.1.5",
       },
     },
   },
@@ -65,19 +65,19 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -159,7 +159,7 @@
 
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
-    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
   }

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -387,6 +387,90 @@ const JSDOC_CATALOG = {
  * for returned promises to resolve before exiting, giving the plugin a
  * chance to flush state.
  */`,
+      triggerConversation: `/**
+ * Start a new conversation turn from a proactive plugin signal (for example
+ * when the plugin observes that a meeting-request mail just arrived and the
+ * user should respond).
+ *
+ * Capability gate: the plugin's manifest must declare \`conversation-trigger\`,
+ * otherwise the host returns \`{ accepted: false, reason: "capability_denied" }\`.
+ * Branch on \`accepted\` — this case is not signalled by an exception.
+ *
+ * Safety contract — caller MUST follow:
+ *  - \`spec.prompt\` is a templated message owned by the plugin, NOT raw
+ *    third-party content (mail body, transcript, etc.). Both \`prompt\` and
+ *    \`context\` are recorded into the host audit chain.
+ *  - \`spec.source\` must match \`^proactive:[a-z][a-z0-9-]*$\` and identify
+ *    the originating signal.
+ *  - Use \`spec.dedupeKey\` to suppress duplicate triggers for the same
+ *    underlying observation.
+ *
+ * @param spec - Trigger payload. See \`ConversationTriggerSpec\`.
+ * @returns A \`ConversationTriggerResult\` describing whether the trigger was
+ *          accepted. When \`accepted\` is \`false\`, \`reason\` carries the cause.
+ */`,
+    },
+  },
+  ConversationTriggerSpec: {
+    leading: `/**
+ * Spec for \`PluginHostApi.triggerConversation()\`. Passed by a brain plugin
+ * when it decides a signal warrants starting a conversation.
+ *
+ * Treat all string fields as plugin-owned: do NOT inline raw third-party
+ * content (mail bodies, transcripts) into \`prompt\` or \`context\` — the host
+ * will record both into its audit chain.
+ */`,
+    fields: {
+      prompt: `/** Templated message — NEVER raw third-party content. See safety contract on \`PluginHostApi.triggerConversation\`. */`,
+      source: `/** Origin tag identifying the signal. Must match \`^proactive:[a-z][a-z0-9-]*$\` (for example \`proactive:meeting-detection\`). */`,
+      context: `/**
+ * Side-channel metadata (IDs, references) recorded with the trigger.
+ *
+ * **P0 limitation:** the host currently records \`context\` only into the
+ * audit chain — the ConversationLoop pipeline (system-prompt builder, tools,
+ * history) does NOT receive it. Plugins that need the LLM or tools to act on
+ * an ID (for example \`emailId\`) MUST embed the ID in \`prompt\` itself so it
+ * survives the trip into the loop. A future P2 will wire \`context\` into
+ * per-turn metadata; the field is kept now so adding plumbing later is
+ * non-breaking.
+ *
+ * @optional
+ */`,
+      visibility: `/**
+ * UI behaviour:
+ *  - \`silent\` — run without surfacing to the user; only audit + result tools.
+ *  - \`summary-only\` — show one-line completion notice (default).
+ *  - \`user-visible\` — surface as if the user opened a turn, modal-style.
+ *
+ * **P0 limitation:** all three values currently produce identical UI
+ * behaviour — recorded into audit only. P2 will add the actual UI branching.
+ *
+ * @optional
+ */`,
+      priority: `/** Routing hint for queueing when multiple triggers compete (audit-only in P0). @optional */`,
+      dedupeKey: `/** Suppress duplicate triggers for the same observation. The dedupe window is enforced by the host. @optional */`,
+    },
+  },
+  ConversationTriggerResult: {
+    leading: `/**
+ * Outcome of a \`PluginHostApi.triggerConversation()\` call. When \`accepted\`
+ * is \`false\`, \`reason\` describes why; \`source\` is echoed back so callers can
+ * correlate logs across plugin and host.
+ */`,
+    fields: {
+      accepted: `/** Whether the trigger was accepted for execution. */`,
+      reason: `/**
+ * When \`accepted\` is \`false\`, the cause:
+ *  - \`capability_denied\` — plugin lacks \`conversation-trigger\`.
+ *  - \`invalid_source\` — \`source\` does not match \`^proactive:[a-z][a-z0-9-]*$\`,
+ *    \`prompt\` empty, or other shape problem.
+ *  - \`duplicate\` — \`dedupeKey\` matched a recent trigger.
+ *  - \`rate_limited\` — per-plugin call cap exceeded (sliding window).
+ *  - \`loop_unavailable\` — ConversationLoop not yet bound (boot ordering).
+ *
+ * @optional
+ */`,
+      source: `/** Echoed back from the request so callers can correlate logs across plugin and host. */`,
     },
   },
   PluginMethodHandler: {

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -388,89 +388,42 @@ const JSDOC_CATALOG = {
  * chance to flush state.
  */`,
       triggerConversation: `/**
- * Start a new conversation turn from a proactive plugin signal (for example
- * when the plugin observes that a meeting-request mail just arrived and the
- * user should respond).
+ * Start a conversation turn from a proactive plugin signal.
  *
- * Capability gate: the plugin's manifest must declare \`conversation-trigger\`,
- * otherwise the host returns \`{ accepted: false, reason: "capability_denied" }\`.
- * Branch on \`accepted\` — this case is not signalled by an exception.
- *
- * Safety contract — caller MUST follow:
- *  - \`spec.prompt\` is a templated message owned by the plugin, NOT raw
- *    third-party content (mail body, transcript, etc.). Both \`prompt\` and
- *    \`context\` are recorded into the host audit chain.
- *  - \`spec.source\` must match \`^proactive:[a-z][a-z0-9-]*$\` and identify
- *    the originating signal.
- *  - Use \`spec.dedupeKey\` to suppress duplicate triggers for the same
- *    underlying observation.
- *
- * @param spec - Trigger payload. See \`ConversationTriggerSpec\`.
- * @returns A \`ConversationTriggerResult\` describing whether the trigger was
- *          accepted. When \`accepted\` is \`false\`, \`reason\` carries the cause.
+ * Capability-gated by \`conversation-trigger\` in the plugin manifest; missing
+ * capability returns \`{ accepted: false, reason: "capability_denied" }\` (no
+ * exception). \`spec.prompt\` MUST be a templated, plugin-owned message — NOT
+ * raw third-party content (mail body, transcript). \`spec.source\` MUST match
+ * \`^proactive:[a-z][a-z0-9-]*$\`.
  */`,
     },
   },
   ConversationTriggerSpec: {
-    leading: `/**
- * Spec for \`PluginHostApi.triggerConversation()\`. Passed by a brain plugin
- * when it decides a signal warrants starting a conversation.
- *
- * Treat all string fields as plugin-owned: do NOT inline raw third-party
- * content (mail bodies, transcripts) into \`prompt\` or \`context\` — the host
- * will record both into its audit chain.
- */`,
+    leading: `/** Spec for \`PluginHostApi.triggerConversation()\`. */`,
     fields: {
-      prompt: `/** Templated message — NEVER raw third-party content. See safety contract on \`PluginHostApi.triggerConversation\`. */`,
-      source: `/** Origin tag identifying the signal. Must match \`^proactive:[a-z][a-z0-9-]*$\` (for example \`proactive:meeting-detection\`). */`,
-      context: `/**
- * Side-channel metadata (IDs, references) recorded with the trigger.
- *
- * **P0 limitation:** the host currently records \`context\` only into the
- * audit chain — the ConversationLoop pipeline (system-prompt builder, tools,
- * history) does NOT receive it. Plugins that need the LLM or tools to act on
- * an ID (for example \`emailId\`) MUST embed the ID in \`prompt\` itself so it
- * survives the trip into the loop. A future P2 will wire \`context\` into
- * per-turn metadata; the field is kept now so adding plumbing later is
- * non-breaking.
- *
- * @optional
- */`,
-      visibility: `/**
- * UI behaviour:
- *  - \`silent\` — run without surfacing to the user; only audit + result tools.
- *  - \`summary-only\` — show one-line completion notice (default).
- *  - \`user-visible\` — surface as if the user opened a turn, modal-style.
- *
- * **P0 limitation:** all three values currently produce identical UI
- * behaviour — recorded into audit only. P2 will add the actual UI branching.
- *
- * @optional
- */`,
-      priority: `/** Routing hint for queueing when multiple triggers compete (audit-only in P0). @optional */`,
-      dedupeKey: `/** Suppress duplicate triggers for the same observation. The dedupe window is enforced by the host. @optional */`,
+      prompt: `/** Templated, plugin-owned message. NEVER raw third-party content (mail body, transcript). Recorded into audit. */`,
+      source: `/** Origin tag. Must match \`^proactive:[a-z][a-z0-9-]*$\`. */`,
+      context: `/** Audit-only side-channel. NOT plumbed into the conversation loop — embed any ID needed by the LLM or tools in \`prompt\` instead. @optional */`,
+      visibility: `/** UI mode: \`silent\` / \`summary-only\` (default) / \`user-visible\`. P0 treats all three identically. @optional */`,
+      priority: `/** Queueing hint when multiple triggers compete. Audit-only in P0. @optional */`,
+      dedupeKey: `/** Suppress duplicate triggers for the same observation; dedupe window enforced by host. @optional */`,
     },
   },
   ConversationTriggerResult: {
-    leading: `/**
- * Outcome of a \`PluginHostApi.triggerConversation()\` call. When \`accepted\`
- * is \`false\`, \`reason\` describes why; \`source\` is echoed back so callers can
- * correlate logs across plugin and host.
- */`,
+    leading: `/** Outcome of \`PluginHostApi.triggerConversation()\`. */`,
     fields: {
       accepted: `/** Whether the trigger was accepted for execution. */`,
       reason: `/**
- * When \`accepted\` is \`false\`, the cause:
+ * Cause when \`accepted\` is \`false\`:
  *  - \`capability_denied\` — plugin lacks \`conversation-trigger\`.
- *  - \`invalid_source\` — \`source\` does not match \`^proactive:[a-z][a-z0-9-]*$\`,
- *    \`prompt\` empty, or other shape problem.
+ *  - \`invalid_source\` — \`source\` does not match \`^proactive:[a-z][a-z0-9-]*$\`, or \`prompt\` empty/oversized.
  *  - \`duplicate\` — \`dedupeKey\` matched a recent trigger.
- *  - \`rate_limited\` — per-plugin call cap exceeded (sliding window).
- *  - \`loop_unavailable\` — ConversationLoop not yet bound (boot ordering).
+ *  - \`rate_limited\` — per-plugin call cap exceeded.
+ *  - \`loop_unavailable\` — ConversationLoop not yet bound at boot.
  *
  * @optional
  */`,
-      source: `/** Echoed back from the request so callers can correlate logs across plugin and host. */`,
+      source: `/** Echoed from the request so callers can correlate logs. */`,
     },
   },
   PluginMethodHandler: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,75 +344,41 @@ export interface PluginHostApi {
   triggerConversation(spec: ConversationTriggerSpec): Promise<ConversationTriggerResult>;
 }
 
-/**
- * Spec for `PluginHostApi.triggerConversation()`. Passed by a brain plugin
- * when it decides a signal warrants starting a conversation.
- *
- * Treat all string fields as plugin-owned: do NOT inline raw third-party
- * content (mail bodies, transcripts) into `prompt` or `context` — the host
- * will record both into its audit chain.
- */
+/** Spec for `PluginHostApi.triggerConversation()`. */
 export interface ConversationTriggerSpec {
 
-  /** Templated message — NEVER raw third-party content. See safety contract on `PluginHostApi.triggerConversation`. */
+  /** Templated, plugin-owned message. NEVER raw third-party content (mail body, transcript). Recorded into audit. */
   prompt: string;
 
-  /** Origin tag identifying the signal. Must match `^proactive:[a-z][a-z0-9-]*$` (for example `proactive:meeting-detection`). */
+  /** Origin tag. Must match `^proactive:[a-z][a-z0-9-]*$`. */
   source: string;
 
-  /**
-   * Side-channel metadata (IDs, references) recorded with the trigger.
-   *
-   * **P0 limitation:** the host currently records `context` only into the
-   * audit chain — the ConversationLoop pipeline (system-prompt builder, tools,
-   * history) does NOT receive it. Plugins that need the LLM or tools to act on
-   * an ID (for example `emailId`) MUST embed the ID in `prompt` itself so it
-   * survives the trip into the loop. A future P2 will wire `context` into
-   * per-turn metadata; the field is kept now so adding plumbing later is
-   * non-breaking.
-   *
-   * @optional
-   */
+  /** Audit-only side-channel. NOT plumbed into the conversation loop — embed any ID needed by the LLM or tools in `prompt` instead. @optional */
   context?: Record<string, unknown>;
 
-  /**
-   * UI behaviour:
-   *  - `silent` — run without surfacing to the user; only audit + result tools.
-   *  - `summary-only` — show one-line completion notice (default).
-   *  - `user-visible` — surface as if the user opened a turn, modal-style.
-   *
-   * **P0 limitation:** all three values currently produce identical UI
-   * behaviour — recorded into audit only. P2 will add the actual UI branching.
-   *
-   * @optional
-   */
+  /** UI mode: `silent` / `summary-only` (default) / `user-visible`. P0 treats all three identically. @optional */
   visibility?: "silent" | "summary-only" | "user-visible";
 
-  /** Routing hint for queueing when multiple triggers compete (audit-only in P0). @optional */
+  /** Queueing hint when multiple triggers compete. Audit-only in P0. @optional */
   priority?: "low" | "normal" | "high";
 
-  /** Suppress duplicate triggers for the same observation. The dedupe window is enforced by the host. @optional */
+  /** Suppress duplicate triggers for the same observation; dedupe window enforced by host. @optional */
   dedupeKey?: string;
 }
 
-/**
- * Outcome of a `PluginHostApi.triggerConversation()` call. When `accepted`
- * is `false`, `reason` describes why; `source` is echoed back so callers can
- * correlate logs across plugin and host.
- */
+/** Outcome of `PluginHostApi.triggerConversation()`. */
 export interface ConversationTriggerResult {
 
   /** Whether the trigger was accepted for execution. */
   accepted: boolean;
 
   /**
-   * When `accepted` is `false`, the cause:
+   * Cause when `accepted` is `false`:
    *  - `capability_denied` — plugin lacks `conversation-trigger`.
-   *  - `invalid_source` — `source` does not match `^proactive:[a-z][a-z0-9-]*$`,
-   *    `prompt` empty, or other shape problem.
+   *  - `invalid_source` — `source` does not match `^proactive:[a-z][a-z0-9-]*$`, or `prompt` empty/oversized.
    *  - `duplicate` — `dedupeKey` matched a recent trigger.
-   *  - `rate_limited` — per-plugin call cap exceeded (sliding window).
-   *  - `loop_unavailable` — ConversationLoop not yet bound (boot ordering).
+   *  - `rate_limited` — per-plugin call cap exceeded.
+   *  - `loop_unavailable` — ConversationLoop not yet bound at boot.
    *
    * @optional
    */
@@ -423,7 +389,7 @@ export interface ConversationTriggerResult {
     | "rate_limited"
     | "loop_unavailable";
 
-  /** Echoed back from the request so callers can correlate logs across plugin and host. */
+  /** Echoed from the request so callers can correlate logs. */
   source: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,6 @@ export interface PluginHostApi {
   }): void;
   getSecret(key: string): string | null;
 
-
   getMsGraphToken(): Promise<string | null>;
   startMsGraphAuth(openBrowser: (url: string) => Promise<void>): Promise<void>;
   isMsGraphAuthenticated(): boolean;
@@ -317,20 +316,13 @@ export interface PluginHostApi {
   onMsGraphAuthChange(handler: () => void): void;
   callTool<T = unknown>(toolName: string, payload?: unknown): Promise<T>;
 
-
   withMsGraphRetry<T>(fn: (token: string) => Promise<T>): Promise<T>;
-
-
 
   callLlm(prompt: string, options?: { maxTokens?: number; systemPrompt?: string }): Promise<string>;
 
-
   logEvent(level: "info" | "warn" | "error", message: string, data?: unknown): void;
 
-
   onShutdown(handler: () => void | Promise<void>): void;
-
-
 
   openAuthWindow(options: {
     url: string;
@@ -348,6 +340,37 @@ export interface PluginHostApi {
     httpOnly?: boolean;
     expirationDate?: number;
   }>>;
+
+  triggerConversation(spec: ConversationTriggerSpec): Promise<ConversationTriggerResult>;
+}
+
+export interface ConversationTriggerSpec {
+
+  prompt: string;
+
+  source: string;
+
+  context?: Record<string, unknown>;
+
+  visibility?: "silent" | "summary-only" | "user-visible";
+
+  priority?: "low" | "normal" | "high";
+
+  dedupeKey?: string;
+}
+
+export interface ConversationTriggerResult {
+
+  accepted: boolean;
+
+  reason?:
+    | "capability_denied"
+    | "invalid_source"
+    | "duplicate"
+    | "loop_unavailable"
+    | "disabled";
+
+  source: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,32 +344,86 @@ export interface PluginHostApi {
   triggerConversation(spec: ConversationTriggerSpec): Promise<ConversationTriggerResult>;
 }
 
+/**
+ * Spec for `PluginHostApi.triggerConversation()`. Passed by a brain plugin
+ * when it decides a signal warrants starting a conversation.
+ *
+ * Treat all string fields as plugin-owned: do NOT inline raw third-party
+ * content (mail bodies, transcripts) into `prompt` or `context` — the host
+ * will record both into its audit chain.
+ */
 export interface ConversationTriggerSpec {
 
+  /** Templated message — NEVER raw third-party content. See safety contract on `PluginHostApi.triggerConversation`. */
   prompt: string;
 
+  /** Origin tag identifying the signal. Must match `^proactive:[a-z][a-z0-9-]*$` (for example `proactive:meeting-detection`). */
   source: string;
 
+  /**
+   * Side-channel metadata (IDs, references) recorded with the trigger.
+   *
+   * **P0 limitation:** the host currently records `context` only into the
+   * audit chain — the ConversationLoop pipeline (system-prompt builder, tools,
+   * history) does NOT receive it. Plugins that need the LLM or tools to act on
+   * an ID (for example `emailId`) MUST embed the ID in `prompt` itself so it
+   * survives the trip into the loop. A future P2 will wire `context` into
+   * per-turn metadata; the field is kept now so adding plumbing later is
+   * non-breaking.
+   *
+   * @optional
+   */
   context?: Record<string, unknown>;
 
+  /**
+   * UI behaviour:
+   *  - `silent` — run without surfacing to the user; only audit + result tools.
+   *  - `summary-only` — show one-line completion notice (default).
+   *  - `user-visible` — surface as if the user opened a turn, modal-style.
+   *
+   * **P0 limitation:** all three values currently produce identical UI
+   * behaviour — recorded into audit only. P2 will add the actual UI branching.
+   *
+   * @optional
+   */
   visibility?: "silent" | "summary-only" | "user-visible";
 
+  /** Routing hint for queueing when multiple triggers compete (audit-only in P0). @optional */
   priority?: "low" | "normal" | "high";
 
+  /** Suppress duplicate triggers for the same observation. The dedupe window is enforced by the host. @optional */
   dedupeKey?: string;
 }
 
+/**
+ * Outcome of a `PluginHostApi.triggerConversation()` call. When `accepted`
+ * is `false`, `reason` describes why; `source` is echoed back so callers can
+ * correlate logs across plugin and host.
+ */
 export interface ConversationTriggerResult {
 
+  /** Whether the trigger was accepted for execution. */
   accepted: boolean;
 
+  /**
+   * When `accepted` is `false`, the cause:
+   *  - `capability_denied` — plugin lacks `conversation-trigger`.
+   *  - `invalid_source` — `source` does not match `^proactive:[a-z][a-z0-9-]*$`,
+   *    `prompt` empty, or other shape problem.
+   *  - `duplicate` — `dedupeKey` matched a recent trigger.
+   *  - `rate_limited` — per-plugin call cap exceeded (sliding window).
+   *  - `loop_unavailable` — ConversationLoop not yet bound (boot ordering).
+   *
+   * @optional
+   */
   reason?:
     | "capability_denied"
     | "invalid_source"
     | "duplicate"
-    | "loop_unavailable"
-    | "disabled";
+    | "rate_limited"
+    | "loop_unavailable";
 
+  /** Echoed back from the request so callers can correlate logs across plugin and host. */
   source: string;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Local vitest config — stops vitest's upward config search so it does not
+ * accidentally inherit the parent host repo's `vitest.config.ts`
+ * (which references a `vitest.globalSetup.ts` that does not exist relative
+ * to this package and crashes test startup).
+ *
+ * The plugin-sdk only ships pure-TS tests for `src/keys.ts`; no jsdom,
+ * no global setup, no environment matching needed.
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Auto-generated from `lvis-app/src/plugins/types.ts` via `sync-from-host`.
Adds the SDK type surface for the new "proactive brain" capability
shipped in lvis-app P0 ([lvis-app#215](https://github.com/lvis-project/lvis-app/pull/215)).

## Generated additions

- `PluginHostApi.triggerConversation(spec)` — capability-gated host entry
- `ConversationTriggerSpec` — `{ prompt, source, context?, visibility?, priority?, dedupeKey? }`
- `ConversationTriggerResult` — `{ accepted, reason?, source }`

`reason` is a closed string union of:
`"capability_denied" | "invalid_source" | "duplicate" | "rate_limited" | "loop_unavailable"`.
The host emits all five today; new values would arrive via a host SoT bump
+ this SDK re-sync, so consumers can match the union exhaustively.

## Side fix — vitest config

Pre-existing bug (independent of these types): `bun run test` from this
directory walks up and inherits lvis-app's root `vitest.config.ts`,
which references a parent-relative `globalSetup` that crashes startup.
CI hadn't caught this because the drift-check workflow only runs
`check:drift`, not the `test` script.

Adds a minimal local `vitest.config.ts` so `bun run test` resolves to
this directory and runs cleanly. Mirrors what the existing
`test/keys.test.ts` suite needs — node env, `test/**/*.test.ts` glob.

## Local-review fix-up commit (`e2558e6`)

Addresses the inline review on this PR:

1. **Drift fix.** Original commit was synced before host `03cd7c9`
   ("Copilot round-1 review") which renamed `reason: "disabled"` →
   `"rate_limited"`. Re-ran `bun run sync:from-host` against current host
   `main`. `bun run check:drift` now reports `No drift.`
2. **JSDoc catalog.** `JSDOC_CATALOG` had no entries for
   `triggerConversation` / `ConversationTriggerSpec` /
   `ConversationTriggerResult`, so they were exported to plugin authors
   undocumented. The host-side safety contract (templated prompt, never
   raw third-party content; `context` is audit-only in P0; `source` regex;
   reason-literal semantics) is now preserved in the SDK surface.
3. **CI.** `drift-check.yml` previously triggered only on schedule +
   workflow_dispatch — that's why this drift slipped through. Adds a
   `pull_request` trigger (paths-filtered) and a PR-mode "Fail on drift"
   step. The auto-fix-PR / issue-on-failure steps are gated to
   non-pull_request events.

## Dependency / sequencing

- This PR's types are usable on the lvis-app side **only after** [lvis-app#215](https://github.com/lvis-project/lvis-app/pull/215) lands (the host implements them).
- A downstream plugin PR (`lvis-plugin-work-proactive`) consumes `triggerConversation` and depends on **both** PRs being merged + this SDK pointer bumped in lvis-app's submodule.

## Test plan

- [x] `bun run build` — emits `dist/index.d.ts` with the new exports + 5-literal `reason` union
- [x] `bun run test` — 14/14 pass
- [x] `bun run check:drift` — `No drift.` against `lvis-app/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)