### PR TITLE
chore(keys): reconcile dev-v1 public key with canonical private key

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -21,7 +21,7 @@
  * Values are base64-encoded raw 32-byte ed25519 public keys.
  */
 export const MARKETPLACE_PUBLIC_KEYS: Readonly<Record<string, string>> = Object.freeze({
-  "dev-v1": "gDzzn5UcdQTwFIxXkXdhZU4k85eUyyyFKfd+fvooDhM=",
+  "dev-v1": "POA+RSsCG9akcaH6z410Jssk1FAy1ajA1Q0IWTRjZxg=",
   "poc-v1": "Qm3FUAMek2r5OkXCurgX6dNYSqiT1GRnjb5fWfuOoao=",
 });
 


### PR DESCRIPTION
## Summary

- The `dev-v1` public key in `MARKETPLACE_PUBLIC_KEYS` was incorrect — it did not match the public key derived from the canonical dev-v1 private key in `lvis-marketplace/server/.env.example`.
- Replaced with the correctly derived public key: `POA+RSsCG9akcaH6z410Jssk1FAy1ajA1Q0IWTRjZxg=`
- The mismatch was latent because the dual-sign envelope verifier accepted envelopes via `poc-v1` (S4a dual-sign window). Once `poc-v1` retires in S4b, `dev-v1` needs to stand on its own.

## Test plan

- [x] `bun run build` — passes cleanly
- [x] `bun run test` — 14/14 tests pass (no tests pin the raw key value; structural checks all pass with the new key)
- [x] Key derivation verified: `node` + `crypto` ed25519 from raw seed `1FZSYHgqzY3cRPqFPMEP0DR7G3qesM7eGcB2BVeYzqk=` → `POA+RSsCG9akcaH6z410Jssk1FAy1ajA1Q0IWTRjZxg=`

Closes lvis-project/lvis-app#239

🤖 Generated with [Claude Code](https://claude.com/claude-code)