### PR TITLE
feat(hostapi): remove MS Graph methods from PluginHostApi

### DIFF
--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -337,36 +337,6 @@ const JSDOC_CATALOG = {
  * @param key - Secret key.
  * @returns The secret value, or \`null\` if no secret exists for \`key\`.
  */`,
-      getMsGraphToken: `/**
- * Fetch a cached Microsoft Graph OAuth access token, if the user has
- * completed authentication. Returns \`null\` when no valid token is cached.
- */`,
-      startMsGraphAuth: `/**
- * Begin the Microsoft Graph OAuth authorization flow. The host generates
- * the authorization URL and hands it to \`openBrowser\` so the plugin or UI
- * can open it in the user's default browser.
- *
- * @param openBrowser - Opens the supplied URL for user consent.
- */`,
-      isMsGraphAuthenticated: `/**
- * @returns \`true\` when the host currently holds a valid Microsoft Graph
- *          authentication context for the user.
- */`,
-      getMsGraphAccount: `/**
- * @returns The authenticated Microsoft Graph account identifier (typically
- *          the user principal name), or \`null\` when not authenticated.
- */`,
-      onMsGraphAuthChange: `/**
- * Subscribe to Microsoft Graph authentication state changes. The handler is
- * invoked whenever the user signs in, signs out, or tokens are refreshed.
- */`,
-      withMsGraphRetry: `/**
- * Execute \`fn\` with a freshly acquired Microsoft Graph access token,
- * automatically retrying once on a 401 response with a refreshed token.
- *
- * @param fn - Receives a valid bearer token and performs a Graph call.
- * @returns Whatever \`fn\` returns on success.
- */`,
       callLlm: `/**
  * Invoke the host's configured language model.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,14 +309,7 @@ export interface PluginHostApi {
   }): void;
   getSecret(key: string): string | null;
 
-  getMsGraphToken(): Promise<string | null>;
-  startMsGraphAuth(openBrowser: (url: string) => Promise<void>): Promise<void>;
-  isMsGraphAuthenticated(): boolean;
-  getMsGraphAccount(): string | null;
-  onMsGraphAuthChange(handler: () => void): void;
   callTool<T = unknown>(toolName: string, payload?: unknown): Promise<T>;
-
-  withMsGraphRetry<T>(fn: (token: string) => Promise<T>): Promise<T>;
 
   callLlm(prompt: string, options?: { maxTokens?: number; systemPrompt?: string }): Promise<string>;
 


### PR DESCRIPTION
## Summary

- ms-graph 플러그인이 자체 MSAL + safeStorage 로 인증을 소유하면서 host 측 MS Graph HostApi 메서드 6종이 더 이상 필요 없음
- `getMsGraphToken / startMsGraphAuth / isMsGraphAuthenticated / getMsGraphAccount / onMsGraphAuthChange / withMsGraphRetry` 정의 + sync-from-host JSDoc 제거

## 컨텍스트

MS Graph plugin 통합 작업 (PR 1) 의 일부. architecture.md §9.4a "Plugin-Owned OAuth Authentication" 신정책 — host 는 OAuth 자체를 모르고, 플러그인이 자체 OAuth 라이브러리 + loopback redirect + safeStorage 를 직접 소유.

관련 PR (lvis-app 의 submodule pointer 갱신은 lvis-app PR 에서):
- lvis-plugin-ms-graph: https://github.com/lvis-project/lvis-plugin-ms-graph (initial)
- lvis-app#TBD: feat/ms-graph-plugin-host-migration

## Test plan

- [x] PR 4-agent self-review 통과 (auditor / static-analyzer / security / architect)
- [ ] 다른 플러그인이 위 메서드를 사용 중이지 않은지 확인 (이미 sweep 완료, 0 hit)