### PR TITLE
chore: sync types from host + migrate drift-check to self-hosted ARM64

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   check:
     if: github.repository == 'lvis-project/lvis-plugin-sdk'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, oracle]
     permissions:
       contents: write
       pull-requests: write

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,21 @@ export class MissingDependenciesError extends Error {
   }
 }
 
+export type McpRuntimeSpec =
+  | {
+      transport: "stdio";
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      auth?: "none" | "api-key" | "sso";
+    }
+  | {
+      transport: "http";
+      url: string;
+      auth?: "none" | "api-key" | "sso";
+      allowPrivateNetworks?: boolean;
+    };
+
 /**
  * Catalog entry describing a plugin available for installation through the
  * host marketplace. This is the user-facing summary of a plugin before it is
@@ -284,6 +299,10 @@ export interface PluginMarketplaceItem {
   toolSchemas?: PluginManifest["toolSchemas"];
 
   requires?: RequiresSpec;
+
+  pluginType?: "plugin" | "mcp";
+
+  mcpRuntime?: McpRuntimeSpec;
 }
 
 /**


### PR DESCRIPTION
Two bundled changes: (a) regenerate src/index.ts from canonical lvis-app/src/plugins/types.ts via sync-from-host.mjs, (b) move drift-check workflow off ubuntu-latest onto the self-hosted oracle ARM64 runner consistent with other repos.