### PR TITLE
chore: address Copilot review comments from PRs #32, #33

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -14,7 +14,10 @@ concurrency:
 jobs:
   check:
     if: github.repository == 'lvis-project/lvis-plugin-sdk'
-    runs-on: [self-hosted, linux, arm64, oracle]
+    # pull_request runs on a GitHub-hosted runner to avoid executing
+    # PR-controlled code (bun install + node script) on the self-hosted
+    # Oracle machine. schedule/workflow_dispatch use the self-hosted runner.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","linux","arm64","oracle"]') }}
     permissions:
       contents: write
       pull-requests: write

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -22,7 +22,12 @@ export const MARKETPLACE_PUBLIC_KEYS: Readonly<Record<string, string>> = Object.
  * pre-prod still uses POC keys, prod rotation is handled by shipping a new
  * SDK major (additive add, then remove the old key in a later major).
  */
-export function getTrustedMarketplacePublicKeys(): Readonly<Record<string, string>> {
+export function getTrustedMarketplacePublicKeys(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _options?: { includeTestKeys?: boolean },
+): Readonly<Record<string, string>> {
+  // Single-key model: options parameter retained for backwards-compatibility
+  // with TypeScript consumers that pass { includeTestKeys } — ignored at runtime.
   return MARKETPLACE_PUBLIC_KEYS;
 }
 

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -56,7 +56,7 @@ describe("MARKETPLACE_PUBLIC_KEYS", () => {
   });
 
   it("getTrustedMarketplacePublicKeys returns the same map", () => {
-    expect(getTrustedMarketplacePublicKeys()).toEqual(MARKETPLACE_PUBLIC_KEYS);
+    expect(getTrustedMarketplacePublicKeys()).toBe(MARKETPLACE_PUBLIC_KEYS);
   });
 });
 


### PR DESCRIPTION
## Summary

- **drift-check.yml** (#32): Switch `pull_request` trigger to `ubuntu-latest` to prevent untrusted PR code from executing on the self-hosted Oracle runner; `schedule`/`workflow_dispatch` keep the self-hosted runner.
- **src/keys.ts** (#33): Restore optional `options?: { includeTestKeys?: boolean }` parameter on `getTrustedMarketplacePublicKeys()` for TypeScript backwards-compatibility; ignored at runtime under the single-key model.
- **test/keys.test.ts** (#33): Change `toEqual` → `toBe` to assert the helper returns the exact same object reference (thin alias, not a clone).

## Test plan
- [x] `npm test` — 10/10 tests pass
- [ ] CI drift-check passes on GitHub Actions

Closes Copilot review comments on #32 and #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)