### PR TITLE
chore: address Copilot round 2 review comment from PR #34

### DIFF
--- a/src/keys.ts
+++ b/src/keys.ts
@@ -23,11 +23,10 @@ export const MARKETPLACE_PUBLIC_KEYS: Readonly<Record<string, string>> = Object.
  * SDK major (additive add, then remove the old key in a later major).
  */
 export function getTrustedMarketplacePublicKeys(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _options?: { includeTestKeys?: boolean },
+  options?: { includeTestKeys?: boolean },
 ): Readonly<Record<string, string>> {
   // Single-key model: options parameter retained for backwards-compatibility
-  // with TypeScript consumers that pass { includeTestKeys } — ignored at runtime.
+  // with TypeScript consumers that pass { includeTestKeys: true } — ignored at runtime.
   return MARKETPLACE_PUBLIC_KEYS;
 }
 


### PR DESCRIPTION
## Summary

- Drop the `// eslint-disable-next-line @typescript-eslint/no-unused-vars` directive from `getTrustedMarketplacePublicKeys()` — the repo has no ESLint config/scripts so the comment is pure noise.
- Rename `_options?` back to `options?` so the published `.d.ts` exposes a clean public API name, per Copilot's suggestion on PR #34.

## Test plan

- [x] `npm run build` — tsc clean, zero errors
- [x] `npm test` — 10/10 tests pass
- [x] Generated `.d.ts` will show `options?` not `_options?`

Closes Copilot comment on #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)