### PR TITLE
feat(types): add PluginRuntimeContext.pluginDataDir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,8 @@ export interface PluginRuntimeContext {
   pluginRoot: string;
   /** Absolute filesystem path to the host's working directory. Plugins should avoid writing here directly. */
   hostRoot: string;
+
+  pluginDataDir: string;
   /** Merged configuration (manifest defaults + user overrides) for this plugin instance. @optional */
   config?: Record<string, unknown>;
   /**


### PR DESCRIPTION
Adds the per-plugin writable data directory contract sync'd from lvis-app. Coordinated with host-side wiring + plugin migrations (meeting / pageindex / ms-graph).