### PR TITLE
chore: sync storage encoding from host

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@lvis/plugin-sdk",
+      "devDependencies": {
+        "typescript": "^6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "scripts": {
     "sync:from-host": "node scripts/sync-from-host.mjs",
     "check:drift": "node scripts/sync-from-host.mjs --check"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
   }
 }

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -634,7 +634,8 @@ try {
   const rendered = render(extract(hostPath));
   const sanitized = sanitizeForPublic(rendered);
   const output = normalizeSdkTypeOnlySurface(enrichWithJsDoc(sanitized, JSDOC_CATALOG))
-    .replace(/\r(?!\n)/g, "\n")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
     .replace(/^[ \t]+$/gm, "")
     .replace(/\n{3,}/g, "\n\n");
   const target = path.join(ROOT, "src/index.ts");

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,10 +305,6 @@ export interface PluginMarketplaceItem {
   mcpRuntime?: McpRuntimeSpec;
 }
 
-/**
- * Supported text encodings for PluginStorage read/write operations.
- * Defined explicitly to avoid a dependency on @types/node in the SDK public surface.
- */
 export type StorageEncoding =
   | "utf-8"
   | "utf8"
@@ -367,20 +363,13 @@ export interface PluginHostApi {
   }): void;
   getSecret(key: string): string | null;
 
-
   callTool<T = unknown>(toolName: string, payload?: unknown): Promise<T>;
-
-
 
   callLlm(prompt: string, options?: { maxTokens?: number; systemPrompt?: string }): Promise<string>;
 
-
   logEvent(level: "info" | "warn" | "error", message: string, data?: unknown): void;
 
-
   onShutdown(handler: () => void | Promise<void>): void;
-
-
 
   openAuthWindow(options: {
     url: string;
@@ -398,7 +387,6 @@ export interface PluginHostApi {
     httpOnly?: boolean;
     expirationDate?: number;
   }>>;
-
 
   triggerConversation(spec: ConversationTriggerSpec): Promise<ConversationTriggerResult>;
 }


### PR DESCRIPTION
Regenerates the source-only SDK type surface after lvis-app switched PluginStorage to the self-contained StorageEncoding union.\n\nValidation:\n- bun run check:drift\n\nCloses #31\nCloses #29\nCloses #28\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>