### PR TITLE
chore(legacy): drop PluginMethodHandler alias and sibling-path lookup

### DIFF
--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -8,9 +8,7 @@
  *
  * Host source resolution (in order):
  *   1. LVIS_HOST_TYPES_PATH env var pointing to a local types.ts file.
- *   2. Local LVIS workspace sibling (`../lvis-app/src/plugins/types.ts`).
- *   3. Vendored app package location (`../../src/plugins/types.ts`).
- *   4. Git clone via LVIS_HOST_REPO_URL + HOST_REF (default branch: main).
+ *   2. Git clone via LVIS_HOST_REPO_URL + HOST_REF (default branch: main).
  * If none is available, the script errors out.
  */
 
@@ -30,16 +28,6 @@ function resolveHostTypesPath() {
   const envPath = process.env.LVIS_HOST_TYPES_PATH;
   if (envPath && fs.existsSync(envPath)) {
     return { path: envPath, source: `env:${envPath}` };
-  }
-
-  const localCandidates = [
-    path.resolve(ROOT, "..", "lvis-app", "src", "plugins", "types.ts"),
-    path.resolve(ROOT, "..", "..", "src", "plugins", "types.ts"),
-  ];
-  for (const candidate of localCandidates) {
-    if (fs.existsSync(candidate)) {
-      return { path: candidate, source: `local:${candidate}` };
-    }
   }
 
   const url = process.env.LVIS_HOST_REPO_URL;
@@ -409,12 +397,6 @@ const JSDOC_CATALOG = {
       source: `/** Echoed from the request so callers can correlate logs. */`,
     },
   },
-  PluginMethodHandler: {
-    leading: `/**
- * Alias of \`PluginToolHandler\` retained for older call sites that describe
- * the same function in method-style terminology.
- */`,
-  },
   PluginRuntimeContext: {
     leading: `/**
  * Execution context supplied by the host when instantiating a plugin through
@@ -597,7 +579,11 @@ function normalizeSdkTypeOnlySurface(text) {
     .replace(
       /^\s*deliveryMode\?: PluginDeliveryMode;\r?\n/gm,
       "",
-    );
+    )
+    // PluginMethodHandler was a backward-compat alias for PluginToolHandler.
+    // The plugins-no-longer-submodules milestone removed all consumers; drop
+    // it from the SDK public surface while keeping the host source unchanged.
+    .replace(/^export type PluginMethodHandler = PluginToolHandler;\r?\n+/m, "");
 
   out = out.replace(
     /^export class PluginStorageError extends Error \{\r?\n(?:.*\r?\n)*?^\}\r?\n+/m,

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,12 +441,6 @@ export interface ConversationTriggerResult {
 }
 
 /**
- * Alias of `PluginToolHandler` retained for older call sites that describe
- * the same function in method-style terminology.
- */
-export type PluginMethodHandler = PluginToolHandler;
-
-/**
  * Execution context supplied by the host when instantiating a plugin through
  * its `RuntimePluginFactory`. The context gives the plugin access to its
  * configuration, its filesystem roots, a scoped logger, and the full host


### PR DESCRIPTION
## Summary

Two backward-compat fallbacks removed from `@lvis/plugin-sdk`.

### 1. `PluginMethodHandler` type alias

**Grep evidence — zero consumers across all 5 plugins:**

| Plugin | Result |
|--------|--------|
| `lvis-plugin-meeting` | no hits |
| `lvis-plugin-pageindex` | no hits |
| `lvis-plugin-email` | no hits |
| `lvis-plugin-calendar` | no hits |
| `lvis-plugin-agent-hub` | no hits |

The alias (`export type PluginMethodHandler = PluginToolHandler`) still exists in the host `types.ts` (it is not our change to make there), so it is filtered out during generation in `normalizeSdkTypeOnlySurface()` — same pattern already used for `DeploymentMode` and `PluginDeliveryMode`. This keeps `check:drift` clean.

### 2. `sync-from-host.mjs` sibling-path fallback

Removed the two local candidate paths from `resolveHostTypesPath()`:
- `../lvis-app/src/plugins/types.ts` (SDK-as-submodule-sibling-of-lvis-app)
- `../../src/plugins/types.ts` (vendored app package layout)

Both were dead after the plugins-no-longer-submodules milestone. The active resolution order is now:
1. `LVIS_HOST_TYPES_PATH` env var
2. `LVIS_HOST_REPO_URL` git clone (CI path)

## Verification

| Check | Result |
|-------|--------|
| `bun install --frozen-lockfile` | ✓ clean |
| `bun run check:drift` (with `LVIS_HOST_TYPES_PATH` pointing to lvis-app) | ✓ No drift |
| `tsc --noEmit --strict src/index.ts` | ✓ zero errors |
| `bun run typecheck` / `bun run test` / `bun run build` | N/A — SDK is type-only, no build/test scripts in package.json |

## Breaking-change candidates

None. `PluginToolHandler` (the canonical name) is unchanged. Any code that imported `PluginMethodHandler` would have received a type error on upgrade — grep confirms no such code exists in any plugin repo.