### PR TITLE
chore: publish pipeline + bump to v2.1.0 (Track B PluginConfigSchema)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v2.1.0) — must already exist on main'
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: Read version from package.json
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate tag matches package version
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          PKG_VERSION="${{ steps.pkg.outputs.version }}"
+          if [ "$TAG" != "v$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          if [ -f CHANGELOG.md ]; then
+            # Extract the section for this tag between two h2 headings
+            NOTES=$(awk "/^## \[?${TAG#v}\]?/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+            if [ -z "$NOTES" ]; then
+              NOTES="See commit history for changes in this release."
+            fi
+          else
+            NOTES="See commit history for changes in this release."
+          fi
+          # Write to file to avoid quoting issues
+          echo "$NOTES" > /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -22,27 +22,34 @@ export default createPlugin;
 
 ## Install
 
-During pre-npm development, consume the SDK as a normal Git dependency:
+Consume the SDK as a Git dependency pinned to a release tag:
 
 ```json
 {
   "devDependencies": {
-    "@lvis/plugin-sdk": "github:lvis-project/lvis-plugin-sdk#v2.0.0"
-  }
-}
-```
-
-After npm publication, use a normal semver range:
-
-```json
-{
-  "devDependencies": {
-    "@lvis/plugin-sdk": "^2.0.0"
+    "@lvis/plugin-sdk": "github:lvis-project/lvis-plugin-sdk#v2.1.0"
   }
 }
 ```
 
 No submodule is required.
+
+### Upgrading
+
+To pull in a new SDK release, update the tag in your `package.json` and reinstall:
+
+```bash
+# bun (recommended)
+bun update @lvis/plugin-sdk
+# or pin explicitly:
+bun add -d github:lvis-project/lvis-plugin-sdk#v2.1.0
+
+# npm
+npm install --save-dev github:lvis-project/lvis-plugin-sdk#v2.1.0
+```
+
+After upgrading, check your `plugin.json` manifest against the updated JSON
+schema at `node_modules/@lvis/plugin-sdk/schemas/plugin-manifest.schema.json`.
 
 ## Trust model
 
@@ -57,6 +64,16 @@ the commercial IDE/browser marketplace model:
 ## Tag policy
 
 - `v2.0.0+` tags are immutable release points.
-- Consumers should pin a specific tag while the SDK is distributed by GitHub.
-- Moving major tags may be introduced later once repository tag protection is
-  available.
+- Consumers should pin a specific tag (`github:lvis-project/lvis-plugin-sdk#vX.Y.Z`).
+- Each tag push triggers the `release.yml` workflow which creates a corresponding
+  GitHub Release with automated release notes.
+- Tagging follows semver: patch for fixes, minor for additive type changes,
+  major for breaking contract changes.
+
+## Releasing a new version
+
+1. Bump `version` in `package.json` following semver.
+2. Commit: `chore: release vX.Y.Z`
+3. Push the tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. The `release` workflow creates the GitHub Release automatically.
+5. Notify downstream plugin authors to update their `#vX.Y.Z` pin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",


### PR DESCRIPTION
## Summary

- **State C → automation**: `@lvis/plugin-sdk` has never been published to npm; plugins consume it via `github:lvis-project/lvis-plugin-sdk#vX.Y.Z` git-tag installs. No npm publish workflow existed.
- **Track B gap**: commit `4e42979` (PR #46, `PluginConfigSchema` / `configSchema` JSON schema) was merged to `main` but `v2.0.0` still points to the pre-#46 commit `fe5003c`. Plugins pinned to `#v2.0.0` do not see the new types.
- **This PR** closes the gap by bumping to `v2.1.0` and adding a `release.yml` workflow so future releases are automated.

## Changes

| File | Change |
|------|--------|
| `package.json` | `2.0.0` → `2.1.0` |
| `.github/workflows/release.yml` | New workflow: fires on `vX.Y.Z` tag push or `workflow_dispatch`; validates tag vs package version; extracts CHANGELOG section; creates GitHub Release |
| `README.md` | Install snippet updated to `#v2.1.0`; added Upgrading section (bun/npm); Tag policy + release runbook for maintainers |

## Downstream upgrade path

Once this PR is merged and `v2.1.0` tag is pushed, plugin authors update their `package.json`:

```json
"@lvis/plugin-sdk": "github:lvis-project/lvis-plugin-sdk#v2.1.0"
```

Then run:
```bash
bun update @lvis/plugin-sdk
# or: bun add -d github:lvis-project/lvis-plugin-sdk#v2.1.0
```

Affected repos: `lvis-plugin-meeting`, `lvis-plugin-pageindex`
No sdk dep yet: `lvis-plugin-email`, `lvis-plugin-calendar` (no action needed)

## Release runbook (for maintainer after merge)

```bash
git checkout main && git pull
git tag v2.1.0
git push origin v2.1.0
# → release.yml fires → GitHub Release created automatically
```

## Secret requirements for release.yml

The workflow only uses `GITHUB_TOKEN` (built-in) with `contents: write` permission. No additional secrets needed.

## Test plan

- [ ] Merge PR to main
- [ ] Push tag `v2.1.0` following runbook above
- [ ] Verify `release` workflow run completes successfully in Actions tab
- [ ] Verify GitHub Release appears at https://github.com/lvis-project/lvis-plugin-sdk/releases
- [ ] In `lvis-plugin-meeting`, bump dep to `#v2.1.0` and verify `PluginConfigSchema` is importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)