### PR TITLE
chore(sdk): sync window field + bump v2.3.0 (US-A1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -51,7 +51,20 @@
           "defaults": { "type": "object" },
           "entry": { "type": "string" },
           "exportName": { "type": "string" },
-          "page": { "type": "string" }
+          "page": { "type": "string" },
+          "window": {
+            "type": "object",
+            "description": "Optional detachable-window defaults for this UI extension. When present the host creates a detached BrowserWindow for this view using these dimensions / snap hints.",
+            "additionalProperties": false,
+            "properties": {
+              "width": { "type": "integer", "minimum": 120, "maximum": 3840, "description": "Initial window width in DIP pixels" },
+              "height": { "type": "integer", "minimum": 80, "maximum": 2160, "description": "Initial window height in DIP pixels" },
+              "minWidth": { "type": "integer", "minimum": 80 },
+              "minHeight": { "type": "integer", "minimum": 60 },
+              "resizable": { "type": "boolean" },
+              "alwaysOnTop": { "type": "boolean" }
+            }
+          }
         }
       },
       "description": "UI extensions. Kind-specific required fields (embedded-module: entry+exportName; embedded-page: page) are enforced at runtime with soft-fallback — invalid entries are dropped with a console warning, the plugin continues to load."


### PR DESCRIPTION
## Summary
- Add optional `window` object to `ui.items.properties` in `schemas/plugin-manifest.schema.json`, mirroring the host SoT (`lvis-app/schemas/plugin.schema.json` — companion PR: lvis-project/lvis-app#377)
- Bump version `2.2.0` → `2.3.0` for this schema addition
- The `window` field enables plugins to declare detachable-window defaults (width, height, minWidth, minHeight, resizable, alwaysOnTop) per UI extension, consumed by WindowManager

## Test plan
- [ ] Schema validates correctly with `bunx ajv-cli@5 validate --spec=draft7`
- [ ] `bun run check:schema-drift` passes after host PR is merged
- [ ] Tag `v2.3.0` and verify release workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)