### PR TITLE
chore: update schema $id to sdk.lvisai.xyz

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sdk.lvis.com/schemas/plugin.schema.json",
+  "$id": "https://sdk.lvisai.xyz/schemas/plugin.schema.json",
   "title": "LVIS Plugin Manifest",
   "description": "Validates plugin.json manifest files for LVIS plugins (§9)",
   "type": "object",


### PR DESCRIPTION
## Summary
- `schemas/plugin-manifest.schema.json`: `$id` updated from `sdk.lvis.com` → `sdk.lvisai.xyz`

Canonical domain is now `lvisai.xyz`; schema identity URI must reflect production host.

## Test plan
- [ ] Plugin manifest validation against this schema file passes with all plugin repos
- [ ] No validator tools hardcode the old URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)