### PR TITLE
feat(sdk)!: v3.0.0 — description MUST, additionalProperties:false, drop eventPublishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Consume the SDK as a Git dependency pinned to a release tag:
 ```json
 {
   "devDependencies": {
-    "@lvis/plugin-sdk": "github:lvis-project/lvis-plugin-sdk#v2.1.0"
+    "@lvis/plugin-sdk": "github:lvis-project/lvis-plugin-sdk#v3.0.0"
   }
 }
 ```
@@ -56,10 +56,10 @@ To pull in a new SDK release, update the tag in your `package.json` and reinstal
 # bun (recommended)
 bun update @lvis/plugin-sdk
 # or pin explicitly:
-bun add -d github:lvis-project/lvis-plugin-sdk#v2.1.0
+bun add -d github:lvis-project/lvis-plugin-sdk#v3.0.0
 
 # npm
-npm install --save-dev github:lvis-project/lvis-plugin-sdk#v2.1.0
+npm install --save-dev github:lvis-project/lvis-plugin-sdk#v3.0.0
 ```
 
 After upgrading, check your `plugin.json` manifest against the updated JSON

--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ description to every `plugin.json` if not already present.
 enforced). Remove any `permissions` arrays from `plugin.json` manifests.
 
 **`additionalProperties: false`** — the schema now rejects unknown manifest keys.
-Any undocumented fields in `plugin.json` will cause host load failure.
+Any undocumented fields in `plugin.json` will cause host load failure. This
+includes the previously-accepted `permissions[]` field.
+
+**`python` field added** — the `PluginManifest` interface now includes an
+optional `python?: { managedBy?, requirementsLock?, interpreter? }` field for
+Python co-deployment metadata (e.g. pageindex). This was already supported at
+runtime but was previously undeclared in the type.
+
+**`publisher` requires `minLength: 1`** — an empty-string publisher now fails
+schema validation. Either omit the field or provide a non-empty value.
 
 ### Upgrading
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Consume the SDK as a Git dependency pinned to a release tag:
 
 No submodule is required.
 
+### v3.0.0 Migration Guide (breaking)
+
+**`description` is now a required MUST field** (was optional). Add a one-line
+description to every `plugin.json` if not already present.
+
+**`eventPublishes` is removed** — use `emittedEvents` exclusively. Rename any
+`eventPublishes` fields in `plugin.json` to `emittedEvents`. No compat shim.
+
+**`permissions` top-level field is no longer allowed** (`additionalProperties: false`
+enforced). Remove any `permissions` arrays from `plugin.json` manifests.
+
+**`additionalProperties: false`** — the schema now rejects unknown manifest keys.
+Any undocumented fields in `plugin.json` will cause host load failure.
+
 ### Upgrading
 
 To pull in a new SDK release, update the tag in your `package.json` and reinstall:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -219,6 +219,16 @@
       "additionalProperties": false
     },
     "publisher": { "type": "string" },
+    "python": {
+      "type": "object",
+      "description": "Optional Python runtime co-deployment metadata. Host installs declared requirements when managedBy is lvis-app.",
+      "additionalProperties": false,
+      "properties": {
+        "managedBy": { "type": "string", "enum": ["lvis-app", "self"] },
+        "requirementsLock": { "type": "string", "minLength": 1 },
+        "interpreter": { "type": "string" }
+      }
+    },
     "toolSchemas": {
       "type": "object",
       "description": "LLM이 메서드를 호출할 때 사용하는 JSON Schema (draft-07). 키: method 이름, 값: { description, inputSchema }",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -224,7 +224,7 @@
       },
       "additionalProperties": false
     },
-    "publisher": { "type": "string" },
+    "publisher": { "type": "string", "minLength": 1 },
     "python": {
       "type": "object",
       "description": "Optional Python runtime co-deployment metadata. Host installs declared requirements when managedBy is lvis-app.",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -17,6 +17,7 @@
     "name": { "type": "string", "minLength": 1 },
     "description": {
       "type": "string",
+      "minLength": 1,
       "maxLength": 280,
       "description": "Short human-readable summary used in the inactive-plugin catalog LLM sees in the system prompt."
     },

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -225,6 +225,11 @@
       "additionalProperties": false
     },
     "publisher": { "type": "string", "minLength": 1 },
+    "packageName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "npm package name persisted into installed manifests by PluginMarketplaceService for rollback support. Not authored by plugin developers."
+    },
     "python": {
       "type": "object",
       "description": "Optional Python runtime co-deployment metadata. Host installs declared requirements when managedBy is lvis-app.",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -4,8 +4,8 @@
   "title": "LVIS Plugin Manifest",
   "description": "Validates plugin.json manifest files for LVIS plugins (§9)",
   "type": "object",
-  "required": ["id", "name", "version", "entry", "tools"],
-  "additionalProperties": true,
+  "required": ["id", "name", "version", "entry", "tools", "description"],
+  "additionalProperties": false,
   "properties": {
     "id": {
       "type": "string",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -131,6 +131,11 @@
         ]
       }
     },
+    "emittedEvents": {
+      "type": "array",
+      "description": "Event types this plugin emits.",
+      "items": { "type": "string", "minLength": 1 }
+    },
     "startupTimeoutMs": {
       "type": "integer",
       "minimum": 1,

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -206,6 +206,7 @@ describe("PluginManifest — window.defaultMode:detached (2c10491)", () => {
     version: "1.0.0",
     entry: "dist/index.js",
     tools: ["detach_ping"],
+    description: "Test fixture.",
     ui: [
       {
         id: "main-panel",
@@ -283,6 +284,7 @@ describe("PluginManifest — configSchema field (post-#76)", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: ["config_ping"],
+      description: "Test fixture.",
       configSchema: schema,
     };
     const { valid, errors } = validateManifest(manifest);
@@ -426,6 +428,7 @@ describe("EventSubscription — structural validation", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       eventSubscriptions: ["meeting:started", "email:received"],
     };
     expect(Array.isArray(manifest.eventSubscriptions)).toBe(true);
@@ -442,6 +445,7 @@ describe("EventSubscription — structural validation", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       eventSubscriptions: subs,
     };
     expect((manifest.eventSubscriptions as EventSubscription[])[0].type).toBe("meeting:started");
@@ -457,23 +461,23 @@ describe("PluginManifest — capability / event declarations", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       capabilities: ["calendar-source", "mail-source", "meeting-recorder", "conversation-trigger"],
     };
     expect(manifest.capabilities).toContain("calendar-source");
     expect(manifest.capabilities).toContain("conversation-trigger");
   });
 
-  it("eventPublishes and emittedEvents are both accepted", () => {
+  it("emittedEvents is accepted (v3 canonical field)", () => {
     const manifest: PluginManifest = {
       id: "com.example.evt",
       name: "Evt",
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
-      eventPublishes: ["plugin:data:ready"],
+      description: "Test fixture.",
       emittedEvents: ["plugin:data:ready"],
     };
-    expect(manifest.eventPublishes).toContain("plugin:data:ready");
     expect(manifest.emittedEvents).toContain("plugin:data:ready");
   });
 
@@ -484,6 +488,7 @@ describe("PluginManifest — capability / event declarations", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       notificationEvents: [
         { event: "meeting:started", titleField: "title", bodyField: "description" },
         { event: "email:received" },
@@ -500,6 +505,7 @@ describe("PluginManifest — capability / event declarations", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       requires: { capabilities: ["calendar", "email"] },
     };
     expect(manifest.requires?.capabilities).toContain("calendar");
@@ -719,6 +725,7 @@ describe("PluginManifest — edge cases", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
     });
     expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
   });
@@ -730,6 +737,7 @@ describe("PluginManifest — edge cases", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: ["tool_one", "tool_two", "tool_three"],
+      description: "Test fixture.",
     });
     expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
   });
@@ -752,6 +760,7 @@ describe("PluginManifest — edge cases", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
     });
     expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
   });
@@ -764,6 +773,7 @@ describe("PluginManifest — edge cases", () => {
         version: "1.0.0",
         entry: "dist/index.js",
         tools: [],
+        description: "Test fixture.",
         installPolicy: policy,
       };
       expect(manifest.installPolicy).toBe(policy);
@@ -777,6 +787,7 @@ describe("PluginManifest — edge cases", () => {
       version: "1.0.0",
       entry: "dist/index.js",
       tools: [],
+      description: "Test fixture.",
       dependencies: [
         "com.example.simple-dep",
         { pluginId: "com.example.complex-dep", versionRange: ">=1.0.0", required: true },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -127,6 +127,26 @@ describe("PluginManifest — schema validation", () => {
     expect(valid).toBe(false);
   });
 
+  it("rejects unknown top-level key (additionalProperties:false) — permissions example", () => {
+    // Phase 1 breaking change: permissions[] was never read by the host; it is now
+    // explicitly rejected at validation time rather than silently ignored.
+    const { valid } = validateManifest({
+      ...VALID_MINIMAL,
+      permissions: ["tasks", "secrets"],
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("rejects eventPublishes (removed in v3; use emittedEvents instead)", () => {
+    // eventPublishes was the legacy alias for emittedEvents. It is removed in v3.
+    // Manifests using it will fail additionalProperties:false validation.
+    const { valid } = validateManifest({
+      ...VALID_MINIMAL,
+      eventPublishes: ["meeting.summary.created"],
+    });
+    expect(valid).toBe(false);
+  });
+
   it("rejects tool names with dots (underscore format required)", () => {
     const { valid, errors } = validateManifest({
       ...VALID_MINIMAL,

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -57,6 +57,7 @@ describe("PluginManifest — schema validation", () => {
     version: "1.0.0",
     entry: "dist/index.js",
     tools: ["my_plugin_ping"],
+    description: "One-line summary of what this plugin does.",
   };
 
   it("accepts a minimal valid manifest (all required fields)", () => {
@@ -72,7 +73,6 @@ describe("PluginManifest — schema validation", () => {
       capabilities: ["calendar-source", "mail-source"],
       startupTools: ["my_plugin_init"],
       eventSubscriptions: ["meeting:started", "meeting:ended"],
-      eventPublishes: ["plugin:event:fired"],
       emittedEvents: ["plugin:event:fired"],
       uiCallable: ["my_plugin_ping"],
       keywords: [{ keyword: "example", skillId: "example-skill" }],
@@ -113,6 +113,17 @@ describe("PluginManifest — schema validation", () => {
   it("rejects manifest missing required field: tools", () => {
     const { tools: _, ...noTools } = VALID_MINIMAL;
     const { valid } = validateManifest(noTools);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects manifest missing required field: description", () => {
+    const { description: _, ...noDesc } = VALID_MINIMAL;
+    const { valid } = validateManifest(noDesc);
+    expect(valid).toBe(false);
+  });
+
+  it("rejects manifest with empty description", () => {
+    const { valid } = validateManifest({ ...VALID_MINIMAL, description: "" });
     expect(valid).toBe(false);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export interface EventSubscription {
  *   version: "1.0.0",
  *   entry: "dist/index.js",
  *   tools: ["my_plugin_ping"],
+ *   description: "One-line summary of what this plugin does.",
  * };
  */
 export interface PluginManifest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,8 @@ export interface PluginManifest {
   /** Tool names exposed to the host LLM. Each name must match `^[a-zA-Z_][a-zA-Z0-9_]*$` — dots and hyphens are not allowed. */
   tools: string[];
 
-  /** One-line description shown in plugin catalogues and tool pickers. @optional */
-  description?: string;
+  /** One-line description shown in plugin catalogues and the inactive-plugin catalog the LLM sees. Required (MUST). */
+  description: string;
   /** Arbitrary JSON configuration merged into `PluginRuntimeContext.config` at startup. Treat as untrusted user data. @optional */
   config?: Record<string, unknown>;
   /** Sidebar / panel UI extensions contributed by this plugin. @optional */
@@ -96,9 +96,7 @@ export interface PluginManifest {
   /** Tools that the UI is permitted to invoke directly (bypassing the LLM). Use sparingly — prefer LLM-mediated calls. @optional */
   uiCallable?: string[];
 
-  /** Event type names this plugin may emit. Hosts can use this for validation and ownership checks. @optional */
-  eventPublishes?: string[];
-  /** Alias of `eventPublishes` accepted by host bridge paths. @optional */
+  /** Event type names this plugin may emit. Used by the host for validation and ownership checks. @optional */
   emittedEvents?: string[];
 
   /** Events that should be surfaced as host notifications. Each entry names the event and maps fields of its payload to notification title and body. @optional */
@@ -376,7 +374,6 @@ export interface PluginMarketplaceItem {
   keywords?: Array<{ keyword: string; skillId: string }>;
   startupTools?: string[];
   uiCallable?: string[];
-  eventPublishes?: string[];
   emittedEvents?: string[];
   notificationEvents?: Array<{
     event: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,20 @@ export interface PluginManifest {
   >;
 
   /**
+   * Optional Python runtime co-deployment metadata. When present and
+   * `managedBy` is `"lvis-app"`, the host installs the declared Python
+   * requirements at plugin startup (e.g. pageindex). @optional
+   */
+  python?: {
+    /** Whether the host manages the Python environment (`"lvis-app"`) or the plugin handles it (`"self"`). */
+    managedBy?: "lvis-app" | "self";
+    /** Path to the pip-locked requirements file (relative to plugin root). */
+    requirementsLock?: string;
+    /** Python interpreter path override. Falls back to host default when absent. */
+    interpreter?: string;
+  };
+
+  /**
    * Declarative settings schema. When present the host renders a typed
    * configuration form (string → text input, number → number input,
    * boolean → toggle, enum → select, array of strings → tag input,


### PR DESCRIPTION
## Summary
- \`description\` promoted to required MUST field in schema + TypeScript interface
- \`additionalProperties: false\` — schema now rejects unknown manifest keys (breaking); rejects legacy \`permissions[]\` and removed \`eventPublishes\`
- \`eventPublishes\` removed from \`PluginManifest\` interface — canonical field is \`emittedEvents\`
- \`python\` optional field added to \`PluginManifest\` interface (was runtime-supported but untyped)
- \`publisher\` minLength:1 enforced in schema (empty string now invalid)
- Bump version 2.3.0 → **3.0.0** (breaking change per semver)
- README v3.0.0 Migration Guide updated to cover all breaking changes

## Note on src/index.ts
\`src/index.ts\` is AUTO-GENERATED via \`bun run sync:from-host\`. These changes were hand-applied against the host \`lvis-app/src/plugins/types.ts\` (which received the same changes in lvis-app PR #389). Once both PRs merge, the drift-check CI will verify byte-for-byte equivalence between the SDK and host types.

## Dependencies
Requires all 7 plugin PRs (Step 1) to be merged first — \`additionalProperties: false\` will reject manifests that still carry \`permissions\`/\`eventPublishes\`.

## Test plan
- [ ] \`bun test\` passes (including new regression tests for permissions/eventPublishes rejection)
- [ ] Schema validates all plugin manifests (post Step 1 merge)
- [ ] \`description\` missing → validation error
- [ ] \`description: ""\` → validation error (minLength:1)
- [ ] \`permissions: []\` in manifest → validation error (additionalProperties:false)
- [ ] \`eventPublishes\` in manifest → validation error (additionalProperties:false)
- [ ] \`python\` field in manifest → validation passes

## After merge
Tag \`v3.0.0\` must be pushed so plugins can pin \`github:lvis-project/lvis-plugin-sdk#v3.0.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)