### PR TITLE
fix(schema): add defaultMode to window properties (v3.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -63,7 +63,8 @@
               "minWidth": { "type": "integer", "minimum": 80 },
               "minHeight": { "type": "integer", "minimum": 60 },
               "resizable": { "type": "boolean" },
-              "alwaysOnTop": { "type": "boolean" }
+              "alwaysOnTop": { "type": "boolean" },
+              "defaultMode": { "type": "string", "enum": ["embedded", "detached"], "description": "Default window placement mode for the UI extension. 'embedded' renders inside main window; 'detached' opens in floating magnetic-snap window." }
             }
           }
         }


### PR DESCRIPTION
## Summary
- `ui[].window.defaultMode` was present in the TypeScript `PluginUiExtension` type but missing from `schemas/plugin-manifest.schema.json`
- With `additionalProperties: false` active, AJV rejects any `plugin.json` that sets `window.defaultMode` (e.g. meeting plugin's `"detached"`) → meeting #57 `validate/validate` FAIL
- Adds `"defaultMode": { "type": "string", "enum": ["embedded", "detached"] }` to `window.properties`, keeping `additionalProperties: false` intact
- Bumps to **v3.0.1** (patch — schema-only fix, no breaking changes)

## Root cause
Two separate ralph waves added different fields to `window` at different times: one added dimensions (width/height/etc.), another added `defaultMode` to the TS type only — the schema was never updated.

## Test plan
- [ ] Schema JSON is valid (passes `python3 -c "import json; json.load(...)"`)
- [ ] Existing 63 SDK tests pass (1 pre-existing `MissingDependenciesError` failure unrelated to this change)
- [ ] lvis-plugin-meeting CI `validate/validate` passes after merge + tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)