### PR TITLE
feat: export PluginAuthSpec + auth schema field (v3.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -277,6 +277,40 @@
         "maxLength": 64
       }
     },
+    "auth": {
+      "type": "object",
+      "description": "Optional declarative auth contract. Lets the host render a generic 'authentication required / signed in' badge + login/logout button in Settings → 플러그인 설정 without baking plugin-specific auth code into the host. The plugin still owns its OAuth/cookie flow (see architecture.md §9.4a 'Plugin-Owned OAuth Authentication'); the host only invokes the named tools and listens for the auth-changed event. The three tool names referenced here MUST also appear in `uiCallable[]` (cross-field validated in manifest-validation.ts). On state transitions (login success, logout, token refresh failure) the plugin SHOULD emit an event named `<pluginId>.auth.changed` so the host UI can refresh without polling.",
+      "additionalProperties": false,
+      "required": [
+        "statusTool",
+        "loginTool"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Human-readable label for the auth surface, shown next to the badge (e.g. 'Microsoft 계정', 'LGE 포털'). Defaults to the plugin's `name` if omitted.",
+          "maxLength": 64
+        },
+        "statusTool": {
+          "type": "string",
+          "description": "Tool name (must be in `uiCallable[]`) returning `{ authenticated: boolean, account?: string }`. Host invokes on Settings tab mount and after every `<pluginId>.auth.changed` event.",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "maxLength": 64
+        },
+        "loginTool": {
+          "type": "string",
+          "description": "Tool name (must be in `uiCallable[]`) the host invokes when the user clicks the '로그인' button. The plugin owns the actual auth flow (e.g. MSAL interactive, openAuthWindow); the host only triggers it.",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "maxLength": 64
+        },
+        "logoutTool": {
+          "type": "string",
+          "description": "Optional tool name (must be in `uiCallable[]` if present) the host invokes when the user clicks the '로그아웃' button. Omit to render a sign-in-only surface (e.g. plugins that don't support runtime sign-out).",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "maxLength": 64
+        }
+      }
+    },
     "notificationEvents": {
       "type": "array",
       "items": {
@@ -464,6 +498,18 @@
                 "type": "boolean"
               }
             }
+          },
+          "version": {
+            "type": "string",
+            "description": "\u00a76.4 Tool versioning \u2014 optional semver string for this tool. When omitted, the plugin manifest's top-level version is used."
+          },
+          "deprecatedSince": {
+            "type": "string",
+            "description": "Semver string of the manifest version that deprecated this tool."
+          },
+          "replacedBy": {
+            "type": "string",
+            "description": "Tool name that replaces this deprecated tool."
           }
         }
       }

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -163,6 +163,39 @@ const JSDOC_CATALOG = {
       title: `/** Short human-readable label shown in the host UI for this subscription. */`,
     },
   },
+  PluginAuthSpec: {
+    leading: `/**
+ * Optional declarative auth contract for plugins that own their OAuth /
+ * cookie / session flow but want the host to render a generic 미인증 /
+ * signed-in surface in Settings → 플러그인 설정. See lvis-app
+ * \`architecture.md\` §9.4a "Plugin-Owned OAuth — Host UI Surface".
+ *
+ * The three referenced tool names (\`statusTool\`, \`loginTool\`,
+ * \`logoutTool\`) MUST also appear in \`PluginManifest.uiCallable[]\`;
+ * the host validates this cross-field at load time. On state
+ * transitions the plugin SHOULD emit \`<pluginId>.auth.changed\` so
+ * the host UI refreshes without polling.
+ */`,
+    fields: {
+      label: `/** Human-readable label shown next to the badge (defaults to plugin \`name\`). @optional */`,
+      statusTool: `/** Name of a uiCallable tool returning {@link PluginAuthStatus}. */`,
+      loginTool: `/** Name of a uiCallable tool the host invokes when the user clicks "로그인". The plugin owns the actual auth flow (e.g. MSAL interactive, openAuthWindow). */`,
+      logoutTool: `/** Optional uiCallable tool the host invokes when the user clicks "로그아웃". Omit when the plugin has no programmatic sign-out path. @optional */`,
+    },
+  },
+  PluginAuthStatus: {
+    leading: `/**
+ * Recommended return shape of \`auth.statusTool\`. Plugins MAY return
+ * additional fields and the host ignores them. The host parses with a
+ * strict \`=== true\` check on \`authenticated\` — values like \`1\` or
+ * \`"true"\` are deliberately treated as unauthenticated to surface
+ * contract drift.
+ */`,
+    fields: {
+      authenticated: `/** Strict literal \`true\` when the plugin has a usable session; otherwise \`false\`. */`,
+      account: `/** Optional human-readable identity (email, login id) shown next to the green badge. Display only — not a stable id. @optional */`,
+    },
+  },
   EventSubscription: {
     leading: `/**
  * Object form of an event subscription entry. Use when you need to attach a
@@ -207,6 +240,7 @@ const JSDOC_CATALOG = {
       eventPublishes: `/** Event type names this plugin may emit. Hosts can use this for validation and ownership checks. @optional */`,
       emittedEvents: `/** Alias of \`eventPublishes\` accepted by host bridge paths. @optional */`,
       uiCallable: `/** Tools that the UI is permitted to invoke directly (bypassing the LLM). Use sparingly — prefer LLM-mediated calls. @optional */`,
+      auth: `/** Declarative auth contract — see {@link PluginAuthSpec}. When present, the host renders a generic 미인증 / signed-in badge + login/logout button in Settings. @optional */`,
       notificationEvents: `/** Events that should be surfaced as host notifications. Each entry names the event and maps fields of its payload to notification title and body. @optional */`,
       publisher: `/** Display string identifying the plugin publisher (for example an organization or author). @optional */`,
       startupTimeoutMs: `/** Maximum time in milliseconds the host will wait for \`RuntimePlugin.start\` to resolve. Plugins exceeding this are considered failed. @optional */`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,20 +21,45 @@ export interface PluginAccessSpec {
   plugins: PluginAccessTarget[];
 }
 
+/**
+ * Optional declarative auth contract for plugins that own their OAuth /
+ * cookie / session flow but want the host to render a generic 미인증 /
+ * signed-in surface in Settings → 플러그인 설정. See lvis-app
+ * `architecture.md` §9.4a "Plugin-Owned OAuth — Host UI Surface".
+ *
+ * The three referenced tool names (`statusTool`, `loginTool`,
+ * `logoutTool`) MUST also appear in `PluginManifest.uiCallable[]`;
+ * the host validates this cross-field at load time. On state
+ * transitions the plugin SHOULD emit `<pluginId>.auth.changed` so
+ * the host UI refreshes without polling.
+ */
 export interface PluginAuthSpec {
 
+  /** Human-readable label shown next to the badge (defaults to plugin `name`). @optional */
   label?: string;
 
+  /** Name of a uiCallable tool returning {@link PluginAuthStatus}. */
   statusTool: string;
 
+  /** Name of a uiCallable tool the host invokes when the user clicks "로그인". The plugin owns the actual auth flow (e.g. MSAL interactive, openAuthWindow). */
   loginTool: string;
 
+  /** Optional uiCallable tool the host invokes when the user clicks "로그아웃". Omit when the plugin has no programmatic sign-out path. @optional */
   logoutTool?: string;
 }
 
+/**
+ * Recommended return shape of `auth.statusTool`. Plugins MAY return
+ * additional fields and the host ignores them. The host parses with a
+ * strict `=== true` check on `authenticated` — values like `1` or
+ * `"true"` are deliberately treated as unauthenticated to surface
+ * contract drift.
+ */
 export interface PluginAuthStatus {
+  /** Strict literal `true` when the plugin has a usable session; otherwise `false`. */
   authenticated: boolean;
 
+  /** Optional human-readable identity (email, login id) shown next to the green badge. Display only — not a stable id. @optional */
   account?: string;
 }
 
@@ -113,6 +138,7 @@ export interface PluginManifest {
   /** Tools that the UI is permitted to invoke directly (bypassing the LLM). Use sparingly — prefer LLM-mediated calls. @optional */
   uiCallable?: string[];
 
+  /** Declarative auth contract — see {@link PluginAuthSpec}. When present, the host renders a generic 미인증 / signed-in badge + login/logout button in Settings. @optional */
   auth?: PluginAuthSpec;
 
   /** Alias of `eventPublishes` accepted by host bridge paths. @optional */

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,23 @@ export interface PluginAccessSpec {
   plugins: PluginAccessTarget[];
 }
 
+export interface PluginAuthSpec {
+
+  label?: string;
+
+  statusTool: string;
+
+  loginTool: string;
+
+  logoutTool?: string;
+}
+
+export interface PluginAuthStatus {
+  authenticated: boolean;
+
+  account?: string;
+}
+
 /**
  * Optional structured hint attached to an event subscription. Allows the host
  * to surface contextual metadata alongside the subscription.
@@ -95,6 +112,8 @@ export interface PluginManifest {
 
   /** Tools that the UI is permitted to invoke directly (bypassing the LLM). Use sparingly — prefer LLM-mediated calls. @optional */
   uiCallable?: string[];
+
+  auth?: PluginAuthSpec;
 
   /** Alias of `eventPublishes` accepted by host bridge paths. @optional */
   emittedEvents?: string[];
@@ -328,6 +347,7 @@ export interface PluginMarketplaceItem {
   keywords?: Array<{ keyword: string; skillId: string }>;
   startupTools?: string[];
   uiCallable?: string[];
+  auth?: PluginAuthSpec;
   emittedEvents?: string[];
   notificationEvents?: Array<{
     event: string;


### PR DESCRIPTION
Closes #59. Unblocks lvis-plugin-ms-graph #25 + lvis-plugin-lge-api #31.

## Summary

`lvis-app` PR #411 added an optional `auth` manifest field + recommended `{ authenticated, account? }` statusTool return shape (architecture.md §9.4a). The SDK type+schema bump was missed in the same wave, so the reusable `validate-plugin-manifest.yml` workflow used by every plugin repo rejects new manifests with `auth` field as `additionalProperties:false` violation.

## Changes

- `schemas/plugin-manifest.schema.json` — synced from `lvis-app/schemas/plugin.schema.json` via `scripts/sync-schema-from-host.mjs`. Adds the `auth` definition (required `statusTool` + `loginTool`, optional `label` + `logoutTool`).
- `src/index.ts` — synced from host `src/plugins/types.ts`. New exports: `PluginAuthSpec`, `PluginAuthStatus`. `PluginManifest` gains `auth?: PluginAuthSpec`.
- `package.json` — 3.1.0 → 3.2.0 (additive, no breaking changes).

## Test plan

- [x] `bunx vitest run` — 67 / 67 tests pass
- [x] `node scripts/sync-schema-from-host.mjs --check` — no drift vs host
- [x] `node scripts/sync-from-host.mjs --check` — no drift vs host

## Why bump SDK now

Plugin PRs #25 (ms-graph) + #31 (lge-api) cannot pass CI without this — their reusable validate-manifest workflow fetches the SDK schema directly. PR #411 is already merged on host so all the manifest+type work has a stable upstream contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)