### PR TITLE
chore(schema): tighten plugin manifest version to stable-only SemVer

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -38,8 +38,8 @@
     },
     "version": {
       "type": "string",
-      "pattern": "^\\d+\\.\\d+\\.\\d+(-[\\w.]+)?(\\+[\\w.]+)?$",
-      "description": "Anchored semver (MAJOR.MINOR.PATCH with optional -prerelease / +build metadata)"
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+      "description": "Stable SemVer (MAJOR.MINOR.PATCH, no leading zeros). Pre-release / build-metadata suffixes are not supported on the marketplace publish channel — the per-plugin publish.yml rejects them at tag time. Aligning the schema with that gate so AJV fails earlier."
     },
     "entry": {
       "type": "string",
@@ -502,11 +502,13 @@
           },
           "version": {
             "type": "string",
-            "description": "\u00a76.4 Tool versioning \u2014 optional semver string for this tool. When omitted, the plugin manifest's top-level version is used."
+            "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+            "description": "\u00a76.4 Tool versioning \u2014 optional stable SemVer (MAJOR.MINOR.PATCH, no leading zeros) for this tool. When omitted, the plugin manifest's top-level version is used. Same strictness as the top-level version field."
           },
           "deprecatedSince": {
             "type": "string",
-            "description": "Semver string of the manifest version that deprecated this tool."
+            "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+            "description": "Stable SemVer (MAJOR.MINOR.PATCH) of the manifest version that deprecated this tool."
           },
           "replacedBy": {
             "type": "string",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -178,14 +178,23 @@ describe("PluginManifest — schema validation", () => {
     expect(valid).toBe(false);
   });
 
-  it("accepts semver with prerelease tag", () => {
-    const { valid, errors } = validateManifest({ ...VALID_MINIMAL, version: "1.2.3-beta.1" });
-    expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+  it("rejects pre-release tag (stable-only marketplace channel)", () => {
+    // Mirrors the publish.yml SemVer regex — pre-release tags are not a
+    // supported release form on the marketplace today (Channel 3 of
+    // `marketplace-publishing.md`). Rejecting at AJV level surfaces the
+    // mismatch before the plugin author even pushes a tag.
+    const { valid } = validateManifest({ ...VALID_MINIMAL, version: "1.2.3-beta.1" });
+    expect(valid).toBe(false);
   });
 
-  it("accepts semver with build metadata", () => {
-    const { valid, errors } = validateManifest({ ...VALID_MINIMAL, version: "1.2.3+build.42" });
-    expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+  it("rejects build metadata (stable-only marketplace channel)", () => {
+    const { valid } = validateManifest({ ...VALID_MINIMAL, version: "1.2.3+build.42" });
+    expect(valid).toBe(false);
+  });
+
+  it("rejects leading zeros (per SemVer §2)", () => {
+    const { valid } = validateManifest({ ...VALID_MINIMAL, version: "01.2.3" });
+    expect(valid).toBe(false);
   });
 
   it("rejects null top-level object", () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -197,6 +197,36 @@ describe("PluginManifest — schema validation", () => {
     expect(valid).toBe(false);
   });
 
+  // Boundary-table sweep — accept/reject pairs that pin every regex group
+  // independently. Without this, a per-group bug (e.g. `[1-9][0-9]+` instead
+  // of `[1-9][0-9]*` would silently reject single-digit `1.2.3`) could slip
+  // past. Add new rows here when loosening or tightening the contract.
+  it.each([
+    // accepts
+    ["1.0.10", true],
+    ["0.0.0", true],
+    ["10.20.30", true],
+    ["1.2.3", true],
+    // rejects — leading zeros on each component
+    ["01.2.3", false],
+    ["1.02.3", false],
+    ["1.2.03", false],
+    // rejects — wrong shape
+    ["", false],
+    ["1", false],
+    ["1.2", false],
+    ["1.2.3.4", false],
+    ["v1.2.3", false],
+    [" 1.2.3", false],
+    ["1.2.3 ", false],
+    // rejects — pre-release / build metadata (covered above but pinned here too)
+    ["1.2.3-rc.1", false],
+    ["1.2.3+abc", false],
+  ])("version %p — accepts: %p", (version, accepts) => {
+    const { valid } = validateManifest({ ...VALID_MINIMAL, version });
+    expect(valid).toBe(accepts);
+  });
+
   it("rejects null top-level object", () => {
     const { valid } = validateManifest(null);
     expect(valid).toBe(false);


### PR DESCRIPTION
## Summary
\`plugin.json.version\` 의 schema pattern 을 publish.yml 의 SemVer regex 와 일치시킴 — pre-release / build-metadata 거절, leading zero 거절.

| | before | after |
|---|---|---|
| pattern | \`^\\d+\\.\\d+\\.\\d+(-[\\w.]+)?(\\+[\\w.]+)?\$\` | \`^(0\\|[1-9][0-9]*)\\.(0\\|[1-9][0-9]*)\\.(0\\|[1-9][0-9]*)\$\` |
| accepts | \`1.2.3\`, \`1.2.3-rc1\`, \`1.2.3+abc\`, \`01.2.3\` | \`1.2.3\`, \`10.20.30\` |
| rejects | \`1.2\`, \`not-semver\` | + \`1.2.3-rc1\`, \`1.2.3+abc\`, \`01.2.3\` |

## Why
이전엔 SDK schema 와 publish.yml 의 SemVer 룰이 drift:
- SDK 가 \`1.2.3-rc1\` 통과 → 개발자 plugin.json 에 작성 가능
- 그러나 publish.yml 의 tag 검증 (\`^[0-9]+\\.[0-9]+\\.[0-9]+\$\`) 이 거절
- → release 시점에 \"tag must be vMAJOR.MINOR.PATCH SemVer\" 에러로 실패. 어디 룰이 진짜인지 혼란.

이번 정렬로 AJV 가 plugin.json 작성 시점에 fail-fast → 개발자가 더 일찍 mismatch 알아챔.

## Same change applied to
- \`tools[].version\` (§6.4 tool versioning, optional 이지만 작성 시 같은 strictness)
- \`tools[].deprecatedSince\` (semver 라고만 적혀있고 pattern 없었음 — 같은 pattern 추가)

## Tests
- \"accepts pre-release\" / \"accepts build metadata\" → \"**rejects** pre-release\" / \"**rejects** build metadata\" (의도 변경)
- 신규: \"rejects leading zeros\" (per SemVer §2)
- 70/70 pass

## Companion PRs (separate, parallel)
- **lvis-app**: \`manifest-validation.ts\` 의 host-side regex \`/^\\d+\\.\\d+\\.\\d+/\` 도 같은 strictness 로 (이거 \$ anchor 도 없어서 \`1.2.3.4\` 도 통과 — 더 느슨)
- **lvis-plugin-template**: 새 plugin repo 시작점에 \`publish.yml\` + \`RELEASING.md\` template 추가

## Future
pre-release support 는 별도 marketplace channel decision 으로. 그 시점에 schema 다시 완화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)