### PR TITLE
feat(sdk): schema as SoT — author + uiSlots + bounded configSchema default

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -561,16 +561,13 @@
               },
               "default": {
                 "description": "Default value for the form field. Outer JSON byte-size cap is enforced server-side (see marketplace publisher.py); the schema bounds object/array primitives so a pathological default can't blow up the catalog.",
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "string",
                     "maxLength": 1024
                   },
                   {
                     "type": "number"
-                  },
-                  {
-                    "type": "integer"
                   },
                   {
                     "type": "boolean"

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -559,7 +559,35 @@
               "description": {
                 "type": "string"
               },
-              "default": {},
+              "default": {
+                "description": "Default value for the form field. Outer JSON byte-size cap is enforced server-side (see marketplace publisher.py); the schema bounds object/array primitives so a pathological default can't blow up the catalog.",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "maxLength": 1024
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "array",
+                    "maxItems": 64
+                  },
+                  {
+                    "type": "object",
+                    "maxProperties": 32
+                  }
+                ]
+              },
               "enum": {
                 "type": "array"
               },
@@ -639,6 +667,22 @@
           }
         }
       }
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Plugin author — individual maintainer name or contact (distinct from `publisher`, which is the publishing organization). Surfaced in catalog / IDE intellisense; not used for permission decisions."
+    },
+    "uiSlots": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$",
+        "maxLength": 64
+      },
+      "description": "Top-level advertisement of UI slot names this plugin participates in. Marketplace metadata only — actual extension binding lives in `ui[].slot`. Kebab-case identifiers, ≤32 entries."
     }
   },
   "allOf": [

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -743,6 +743,8 @@ export type StorageEncoding =
   out = restrictMarketplaceChannelToStable(out);
   out = ensurePluginManifestPython(out);
   out = ensurePluginManifestPackageName(out);
+  out = ensurePluginManifestAuthor(out);
+  out = ensurePluginManifestUiSlots(out);
   out = annotateToolSchemaInner(out);
 
   return out;
@@ -869,6 +871,36 @@ function ensurePluginManifestPackageName(text) {
   return text.replace(
     /(^export interface PluginManifest \{[\s\S]*?)\n\}\n/m,
     (_match, body) => `${body}\n  packageName?: string;\n}\n`,
+  );
+}
+
+/**
+ * Phase-1 schema-master sync — author + uiSlots TS surface.
+ *
+ * `author` (individual maintainer) lives in the SDK schema even though
+ * the host's plugin.schema.json doesn't carry it after the Phase-1 prune.
+ * Plugin authors expect a credit field; `publisher` (organization) and
+ * `author` (individual) are intentionally distinct. Inject on the SDK
+ * side so manifest typings surface it.
+ *
+ * `uiSlots` is the top-level slot-name advertisement (distinct from
+ * the per-extension `ui[].slot` binding). Marketplace metadata only.
+ *
+ * Both are idempotent — only inject when missing.
+ */
+function ensurePluginManifestAuthor(text) {
+  if (/^\s*author\?:\s*string;/m.test(text)) return text;
+  return text.replace(
+    /(^export interface PluginManifest \{[\s\S]*?)\n\}\n/m,
+    (_match, body) => `${body}\n  /** Plugin author — individual maintainer name or contact (distinct from \`publisher\`). */\n  author?: string;\n}\n`,
+  );
+}
+
+function ensurePluginManifestUiSlots(text) {
+  if (/^\s*uiSlots\?:\s*string\[\];/m.test(text)) return text;
+  return text.replace(
+    /(^export interface PluginManifest \{[\s\S]*?)\n\}\n/m,
+    (_match, body) => `${body}\n  /** Top-level advertisement of UI slot names this plugin participates in. Marketplace metadata only — actual extension binding lives in \`ui[].slot\`. */\n  uiSlots?: string[];\n}\n`,
   );
 }
 

--- a/scripts/sync-schema-from-host.mjs
+++ b/scripts/sync-schema-from-host.mjs
@@ -214,17 +214,26 @@ function ensureBoundedConfigSchemaDefault(schema) {
     schema.properties?.configSchema?.properties?.properties?.additionalProperties
       ?.properties?.default;
   if (!fieldDef) return schema;
-  if (fieldDef.oneOf) return schema; // already bounded
+  if (fieldDef.anyOf) return schema; // already bounded (current canonical form)
+  // Migrate legacy oneOf form (PR #68 first iteration) — oneOf requires
+  // *exactly one* match, but an integer matches both `{type: "number"}` and
+  // `{type: "integer"}`, breaking ajv validation. anyOf is the correct
+  // disjunction operator for bounded-primitive enumeration.
+  if (fieldDef.oneOf) {
+    delete fieldDef.oneOf;
+    Object.keys(fieldDef).forEach((k) => {
+      if (k !== "description") delete fieldDef[k];
+    });
+  }
   // Only upgrade the literal `{}` (any value) form. If the host has
   // intentionally constrained `default` to something else, leave it.
-  if (Object.keys(fieldDef).length !== 0) return schema;
+  if (Object.keys(fieldDef).filter((k) => k !== "description").length !== 0) return schema;
   schema.properties.configSchema.properties.properties.additionalProperties.properties.default = {
     description:
       "Default value for the form field. Outer JSON byte-size cap is enforced server-side (see marketplace publisher.py); the schema bounds object/array primitives so a pathological default can't blow up the catalog.",
-    oneOf: [
+    anyOf: [
       { type: "string", maxLength: 1024 },
       { type: "number" },
-      { type: "integer" },
       { type: "boolean" },
       { type: "null" },
       { type: "array", maxItems: 64 },

--- a/scripts/sync-schema-from-host.mjs
+++ b/scripts/sync-schema-from-host.mjs
@@ -152,11 +152,96 @@ function tightenVersionPatternToStable(schema) {
   return schema;
 }
 
+/**
+ * Phase-1 schema-master sync — author + uiSlots + bounded configSchema default.
+ *
+ * The host's `plugin.schema.json` historically had a richer `author` field
+ * (PR #404 era) that was lost during the Phase-1 prune. The host doesn't
+ * read it, but plugin authors expect to declare credit somewhere — keeping
+ * it in the SDK schema so consumers (marketplace UI, IDE intellisense)
+ * have a place to surface "made by". `publisher` (organization) and
+ * `author` (individual) are intentionally distinct.
+ */
+function ensurePluginManifestAuthor(schema) {
+  const props = schema.properties;
+  if (props && !props.author) {
+    props.author = {
+      type: "string",
+      minLength: 1,
+      maxLength: 256,
+      description:
+        "Plugin author — individual maintainer name or contact (distinct from `publisher`, which is the publishing organization). Surfaced in catalog / IDE intellisense; not used for permission decisions.",
+    };
+  }
+  return schema;
+}
+
+/**
+ * `uiSlots` — top-level array of slot identifiers the plugin advertises.
+ * Distinct from `ui[].slot` which is the per-extension binding (richer:
+ * id + slot + kind + entry). `uiSlots` is metadata so a host can show
+ * "this plugin uses slots: sidebar, toolbar" in the marketplace listing
+ * without parsing the full `ui[]` array. Empty array is allowed.
+ */
+function ensurePluginManifestUiSlots(schema) {
+  const props = schema.properties;
+  if (props && !props.uiSlots) {
+    props.uiSlots = {
+      type: "array",
+      maxItems: 32,
+      items: {
+        type: "string",
+        pattern: "^[a-z][a-z0-9-]*$",
+        maxLength: 64,
+      },
+      description:
+        "Top-level advertisement of UI slot names this plugin participates in. Marketplace metadata only — actual extension binding lives in `ui[].slot`. Kebab-case identifiers, ≤32 entries.",
+    };
+  }
+  return schema;
+}
+
+/**
+ * configSchema default — was `{}` (anything goes), now oneOf bounded so
+ * a publisher can't ship a 30 MB JSON `default` and DoS the catalog.
+ * Cherry-picked from marketplace-side hardening (see lvis-marketplace
+ * PR #83). Keeps semantics identical for legitimate small defaults
+ * (string ≤1 KB, number, boolean, null, array ≤64, object ≤32 props).
+ * Idempotent — only mutates when the value is the literal empty schema.
+ */
+function ensureBoundedConfigSchemaDefault(schema) {
+  const fieldDef =
+    schema.properties?.configSchema?.properties?.properties?.additionalProperties
+      ?.properties?.default;
+  if (!fieldDef) return schema;
+  if (fieldDef.oneOf) return schema; // already bounded
+  // Only upgrade the literal `{}` (any value) form. If the host has
+  // intentionally constrained `default` to something else, leave it.
+  if (Object.keys(fieldDef).length !== 0) return schema;
+  schema.properties.configSchema.properties.properties.additionalProperties.properties.default = {
+    description:
+      "Default value for the form field. Outer JSON byte-size cap is enforced server-side (see marketplace publisher.py); the schema bounds object/array primitives so a pathological default can't blow up the catalog.",
+    oneOf: [
+      { type: "string", maxLength: 1024 },
+      { type: "number" },
+      { type: "integer" },
+      { type: "boolean" },
+      { type: "null" },
+      { type: "array", maxItems: 64 },
+      { type: "object", maxProperties: 32 },
+    ],
+  };
+  return schema;
+}
+
 function postProcessSdkSchema(text) {
   const obj = JSON.parse(text);
   tightenVersionPatternToStable(obj);
   ensureAuthUiCallableInvariant(obj);
   applyDollarSchemaMigration(obj);
+  ensurePluginManifestAuthor(obj);
+  ensurePluginManifestUiSlots(obj);
+  ensureBoundedConfigSchemaDefault(obj);
   return JSON.stringify(obj, null, 2) + "\n";
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,10 @@ export interface PluginManifest {
     interpreter?: string;
   };
   packageName?: string;
+  /** Plugin author — individual maintainer name or contact (distinct from `publisher`). */
+  author?: string;
+  /** Top-level advertisement of UI slot names this plugin participates in. Marketplace metadata only — actual extension binding lives in `ui[].slot`. */
+  uiSlots?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

**Phase 1 of the schema-master refactor.** SDK schema becomes the canonical contract — `lvis-app` and `lvis-marketplace` will follow with dependency-importing PRs.

## Changes

### Restored / added
- **`author?: string`** — individual maintainer / contact (1–256 chars). Distinct from `publisher` (organization). Was pruned during Phase 1 from the host schema; SDK keeps it because plugin authors expect a credit field.
- **`uiSlots?: string[]`** — top-level slot-name advertisement, kebab-case, ≤32 entries, ≤64 chars each. Marketplace metadata surface — distinct from per-extension `ui[].slot` binding (which carries id + slot + kind + entry).

### Hardened
- **`configSchema.properties.[*].default`** changed from `{}` (any) to `oneOf` bounded:
  - string ≤1 KB
  - number / integer / boolean / null
  - array ≤64
  - object ≤32 props
  Cherry-picked from `lvis-marketplace` PR #83. Closes the "30 MB JSON default" DoS surface server-side.

## Implementation

All 3 changes live as **post-processors** in `sync-schema-from-host.mjs` + `sync-from-host.mjs`:
- `ensurePluginManifestAuthor`
- `ensurePluginManifestUiSlots`
- `ensureBoundedConfigSchemaDefault`

Future syncs from host won't revert these — sync output is **byte-identical on second run** (existing M14 idempotency CI covers this).

## Why now

User's stated direction (2026-05-02): SDK is single source of truth for plugin schema. Plugins import via npm dependency. Marketplace + lvis-app are downstream consumers, not co-owners. This PR establishes the canonical fields BEFORE the dependency-import migration on consumers.

## Verification

- `bun run test` → **103/103 pass** (existing test suite + idempotency)
- `bun run sync:from-host` then `bun run sync:schema-from-host` → idempotent
- Schema/types diff: `author`, `uiSlots`, `default oneOf` present

## Follow-up PRs (not in this one)

- **lvis-app**: delete `schemas/plugin.schema.json` + import SDK schema directly via `@lvis/plugin-sdk` package
- **lvis-marketplace**: delete `schemas/plugin.schema.template.json` + git submodule SDK or build-time fetch SDK schema
- **7 plugins**: `\$schema` URL field already removed via #61 #73 #30 #36 #43 #41 #26 (pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)