### PR TITLE
feat(ui): 라이트/HC 테마 토큰 + useTheme data-attribute 전파

### DIFF
--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -1,20 +1,37 @@
 import { useEffect } from "react";
-import type { LvisThemePayload } from "../tokens/index.js";
-import { applyThemeTokens } from "../tokens/inject.js";
 
 type PluginBridge = {
   onEvent: (type: string, handler: (data: unknown) => void) => () => void;
 };
 
+interface ThemePayload {
+  theme?: string;
+  chatTheme?: string;
+  codeTheme?: string;
+  /** Optional explicit token overrides from host. When absent, CSS selectors handle it. */
+  tokens?: Record<string, string>;
+}
+
 /**
- * Subscribe to host theme changes and apply --lvis-* tokens to :root.
+ * Subscribe to host theme changes. Sets data-theme / data-chat-theme /
+ * data-code-theme on <html> so lvis-tokens.css selectors activate, then
+ * applies any explicit token overrides when provided.
  * Call once at the plugin's root component.
  */
 export function useTheme(bridge: PluginBridge): void {
   useEffect(() => {
     const unsub = bridge.onEvent("host.theme.changed", (data) => {
-      const payload = data as LvisThemePayload;
-      if (payload?.tokens) applyThemeTokens(payload.tokens);
+      const payload = data as ThemePayload;
+      if (!payload) return;
+      const root = document.documentElement;
+      if (payload.theme) root.setAttribute("data-theme", payload.theme);
+      if (payload.chatTheme) root.setAttribute("data-chat-theme", payload.chatTheme);
+      if (payload.codeTheme) root.setAttribute("data-code-theme", payload.codeTheme);
+      if (payload.tokens) {
+        for (const [k, v] of Object.entries(payload.tokens)) {
+          root.style.setProperty(k, v);
+        }
+      }
     });
     return unsub;
   }, [bridge]);

--- a/src/ui/tokens/index.ts
+++ b/src/ui/tokens/index.ts
@@ -15,5 +15,6 @@ export type LvisThemePayload = {
   theme: "light" | "dark" | "high-contrast";
   chatTheme: "default" | "purple" | "orange" | "blue";
   codeTheme: "auto" | "light" | "dark";
-  tokens: LvisThemeTokens;
+  /** Optional explicit token values. When absent, CSS data-theme selectors handle theming. */
+  tokens?: Partial<LvisThemeTokens>;
 };

--- a/src/ui/tokens/lvis-tokens.css
+++ b/src/ui/tokens/lvis-tokens.css
@@ -1,36 +1,79 @@
 /* @lvis/plugin-sdk — Plugin UI Tokens
- * These variables are overridden at runtime by the host app's theme engine.
- * Default values are dark-theme fallbacks (Common.png style guide reference).
+ * Default = dark. Host broadcasts theme axis via host.theme.changed;
+ * useTheme() sets data-theme / data-chat-theme on documentElement so these
+ * selectors activate automatically — no JS token-swap needed.
  */
+
+/* ─── Dark (default) ─────────────────────────────────── */
 :root {
-  /* Surfaces */
   --lvis-bg:           #0f0f13;
   --lvis-surface:      #1a1a22;
-
-  /* Text */
   --lvis-fg:           #f5f5f5;
   --lvis-fg-muted:     #888888;
-
-  /* Brand — Primary purple */
   --lvis-primary:      #a078f5;
   --lvis-primary-fg:   #ffffff;
-
-  /* Secondary — neutral dark */
   --lvis-secondary:    #2d2d38;
   --lvis-secondary-fg: #f5f5f5;
-
-  /* Status */
   --lvis-danger:       #f03e2f;
   --lvis-danger-fg:    #ffffff;
   --lvis-warning:      #f5a050;
   --lvis-warning-fg:   #1a1a1a;
   --lvis-success:      #22c55e;
-
-  /* Structure */
   --lvis-border:       #2d2d38;
   --lvis-ring:         #a078f5;
-
-  /* Shape */
   --lvis-radius:       0.6rem;
   --lvis-radius-sm:    0.2rem;
+}
+
+/* ─── Light ──────────────────────────────────────────── */
+:root[data-theme="light"] {
+  --lvis-bg:           #f8f8fc;
+  --lvis-surface:      #ffffff;
+  --lvis-fg:           #1a1a22;
+  --lvis-fg-muted:     #666677;
+  --lvis-primary:      #734dff;
+  --lvis-primary-fg:   #ffffff;
+  --lvis-secondary:    #ebebf5;
+  --lvis-secondary-fg: #1a1a22;
+  --lvis-danger:       #e02020;
+  --lvis-danger-fg:    #ffffff;
+  --lvis-warning:      #d97706;
+  --lvis-warning-fg:   #ffffff;
+  --lvis-success:      #16a34a;
+  --lvis-border:       #d4d4e0;
+  --lvis-ring:         #734dff;
+}
+
+/* ─── High-contrast ──────────────────────────────────── */
+:root[data-theme="high-contrast"] {
+  --lvis-bg:           #000000;
+  --lvis-surface:      #0a0a0a;
+  --lvis-fg:           #ffffff;
+  --lvis-fg-muted:     #cccccc;
+  --lvis-primary:      #c497ef;
+  --lvis-primary-fg:   #000000;
+  --lvis-secondary:    #1a1a1a;
+  --lvis-secondary-fg: #ffffff;
+  --lvis-danger:       #ff4444;
+  --lvis-danger-fg:    #000000;
+  --lvis-warning:      #ffaa00;
+  --lvis-warning-fg:   #000000;
+  --lvis-success:      #00ff88;
+  --lvis-border:       #ffffff;
+  --lvis-ring:         #c497ef;
+}
+
+/* ─── Chat theme accent overrides ────────────────────── */
+:root[data-chat-theme="purple"] {
+  --lvis-primary:    #a078f5;
+  --lvis-ring:       #a078f5;
+}
+:root[data-chat-theme="orange"] {
+  --lvis-primary:    #f5a050;
+  --lvis-primary-fg: #1a1a1a;
+  --lvis-ring:       #f5a050;
+}
+:root[data-chat-theme="blue"] {
+  --lvis-primary:    #60a5fa;
+  --lvis-ring:       #60a5fa;
 }


### PR DESCRIPTION
## 요약

- `lvis-tokens.css`에 라이트 테마, 하이콘트라스트 테마 CSS 셀렉터 기반 토큰 추가
- 채팅 테마 accent (purple/orange/blue) `[data-chat-theme]` 셀렉터 추가
- `useTheme()` 훅이 `host.theme.changed` 수신 시 `data-theme` / `data-chat-theme` / `data-code-theme` 속성을 `document.documentElement`에 설정하도록 변경
- `LvisThemePayload.tokens` 옵셔널로 변경 (CSS 셀렉터가 기본 처리, tokens는 호스트가 직접 값 보낼 때만 사용)

## 연관 PR

lvis-project/lvis-app — `feat/plugin-theme-propagation`: 호스트 IPC 구현

## 테스트 계획

- [ ] Storybook에서 다크/라이트/HC 테마 전환 확인
- [ ] `useTheme` 훅 호출 시 data 속성 설정 확인
- [ ] 기존 테스트 103개 통과 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)