### PR TITLE
fix: TS 6 build (split tsup/tsc) + M8 strip robust to dev-link purge

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "dev:storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "sync:from-host": "node scripts/sync-from-host.mjs",

--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -808,9 +808,13 @@ function stripHostInternalRegistryFields(text) {
     .replace(/^[ \t]+_devLinked\?:\s*boolean;\s*\r?\n/gm, "")
     .replace(/^[ \t]+installSource\?:\s*PluginRegistryEntryInstallSource;\s*\r?\n/gm, "")
     // Without `installSource` consumers no longer need the union; drop the
-    // type alias too so the SDK doesn't ship a dangling export.
+    // type alias too so the SDK doesn't ship a dangling export. Match the
+    // declaration line by name + RHS shape rather than a hard-coded literal
+    // union so this stays correct as host adds/removes install sources
+    // (e.g. lvis-app PR #487 dropped `"dev-link"` and the old regex went
+    // stale, leaving the type stuck in the SDK surface).
     .replace(
-      /^export type PluginRegistryEntryInstallSource = "admin" \| "user" \| "local-dev" \| "dev-link";\r?\n+/m,
+      /^export type PluginRegistryEntryInstallSource = [^;]+;\r?\n+/m,
       "",
     );
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
     "ui/tokens/index": "src/ui/tokens/index.ts",
   },
   format: ["esm"],
-  dts: true,
+  // dts emission is delegated to `tsc -p tsconfig.build.json` (see package.json
+  // build script). tsup's bundled dts path injects `baseUrl: "."` into the
+  // synthetic compile, which TypeScript 6+ rejects with TS5101 — invoking
+  // tsc directly avoids that code path entirely.
+  dts: false,
   clean: true,
   external: ["react", "react-dom"],
 });


### PR DESCRIPTION
## Summary

Two related root-cause fixes that together unblock \`bun run build\` and
\`bun run check:drift\` after the TypeScript 6 upgrade and the host's
\`dev-link\` purge (lvis-app PR #487).

### 1. TS 6 baseUrl injection during dts emit

TypeScript 6.0.3 promoted \`baseUrl\` deprecation to a hard error (TS5101).
This repo's own \`tsconfig.json\` never sets \`baseUrl\`, but tsup's bundled
dts path injects \`baseUrl: compilerOptions.baseUrl || "."\` into a
synthetic compile (\`node_modules/tsup/dist/rollup.js:6837\`), which TS6
then rejects.

**Not fixed by** \`"ignoreDeprecations": "6.0"\` — that just silences the
warning while leaving the deprecated option in the synthetic compile.
That route also kicks the can to TS 7 where the option stops working.

**Fixed by** mirroring \`lvis-plugin-pageindex\`: tsup does esbuild only,
\`tsc\` emits declarations directly. \`tsc\` does not inject \`baseUrl\`, so
the offending code path is never executed.

- \`tsup.config.ts\`: \`dts: false\` (with comment)
- \`tsconfig.build.json\` (new): extends tsconfig, \`emitDeclarationOnly: true\`,
  \`outDir: dist\`, excludes stories/tests so the publishable surface stays
  type-only re-exports
- \`package.json\`: \`build: "tsup && tsc -p tsconfig.build.json"\`

### 2. M8 strip regex stale after dev-link purge

\`stripHostInternalRegistryFields()\` had a hard-coded literal-union match:
\`"admin" | "user" | "local-dev" | "dev-link"\`. lvis-app PR #487 shrank
the host union to \`"admin" | "user" | "local-dev"\`, the regex stopped
matching, the host-internal \`PluginRegistryEntryInstallSource\` leaked
into the SDK public surface, and the M8 negative test caught it.

Replaced the literal-union match with \`[^;]+\` so the line-anchored type
alias declaration strips regardless of which install sources the host
enumerates today.

## Verification

- \`bun run build\` → ESM + DTS both succeed, no TS5101
- \`LVIS_HOST_TYPES_PATH=.../lvis-app/src/plugins/types.ts \\
   node scripts/sync-from-host.mjs\` → src/index.ts regenerates identical
  to main (no PluginRegistryEntryInstallSource leak)
- \`bun run test\` → 103/103 pass

## Follow-up

The pre-push hook's \`check:drift\` step still requires
\`LVIS_HOST_TYPES_PATH\` to be set explicitly even when \`lvis-app\` is a
sibling directory — the error message advertises sibling auto-detection
but the script does not implement it. Tracking that as a separate UX
fix; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)