### PR TITLE
feat(build): defineLvisPluginConfig helper for self-contained plugin bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "./ui/lvis-tokens.css": "./src/ui/tokens/lvis-tokens.css",
     "./build": {
       "types": "./src/build/tsup.ts",
-      "import": "./src/build/tsup.ts"
+      "import": "./dist/build/tsup.js"
     },
     "./schemas/plugin-manifest.schema.json": "./schemas/plugin-manifest.schema.json",
     "./schemas/*": "./schemas/*"
@@ -33,6 +33,7 @@
   ],
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
+    "prepare": "bun run build",
     "dev:storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "sync:from-host": "node scripts/sync-from-host.mjs",

--- a/package.json
+++ b/package.json
@@ -45,13 +45,17 @@
   },
   "peerDependencies": {
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react-dom": ">=18.0.0",
+    "tsup": ">=8.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "tsup": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
-    "prepare": "bun run build",
+    "prepare": "tsup && tsc -p tsconfig.build.json",
     "dev:storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "sync:from-host": "node scripts/sync-from-host.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",
@@ -19,6 +19,10 @@
       "import": "./dist/ui/tokens/index.js"
     },
     "./ui/lvis-tokens.css": "./src/ui/tokens/lvis-tokens.css",
+    "./build": {
+      "types": "./src/build/tsup.ts",
+      "import": "./src/build/tsup.ts"
+    },
     "./schemas/plugin-manifest.schema.json": "./schemas/plugin-manifest.schema.json",
     "./schemas/*": "./schemas/*"
   },

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -175,7 +175,11 @@ describe("defineLvisPluginConfig", () => {
     expect("chokidar").toMatch(noExternal[0]);
   });
 
-  it("rejects empty noExternal override (contract lock)", () => {
+  it("forces noExternal even when user passes an empty array (contract lock)", () => {
+    // The helper ignores user-provided `noExternal` values; the contract
+    // is locked to `[BUNDLE_EVERYTHING_REGEX]`. This test guards against
+    // a regression where `[]` would slip through and bypass the bundle-
+    // everything default.
     const cfg = asSingle(defineLvisPluginConfig({ noExternal: [] }));
     const noExternal = noExternalRegexes(cfg);
     expect(noExternal).toHaveLength(1);

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -32,7 +32,7 @@ function noExternalRegexes(cfg: { noExternal?: unknown }): RegExp[] {
 describe("defineLvisPluginConfig", () => {
   it("emits self-containment defaults when called with no overrides", () => {
     const cfg = asSingle(defineLvisPluginConfig());
-    expect(cfg.entry).toEqual(["src/index.ts", "src/hostPlugin.ts"]);
+    expect(cfg.entry).toEqual(["src/hostPlugin.ts"]);
     expect(cfg.format).toEqual(["esm"]);
     expect(cfg.target).toBe("node20");
     expect(cfg.outDir).toBe("dist");
@@ -116,6 +116,31 @@ describe("defineLvisPluginConfig", () => {
       defineLvisPluginConfig({ target: "es2020", platform: "node" }),
     );
     expect(cfg.external).not.toContain("react");
+  });
+
+  it("auto-detects browser when target is an array containing browser-like target", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ target: ["es2020", "chrome120"] }),
+    );
+    expect(cfg.external).toContain("react");
+    expect(cfg.external).toContain("react-dom");
+  });
+
+  it("treats array of node-only targets as node build", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ target: ["node18", "node20"] }),
+    );
+    expect(cfg.external).not.toContain("react");
+    expect(cfg.external).not.toContain("react-dom");
+  });
+
+  it("supports extending entry with src/index.ts via override", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        entry: ["src/index.ts", "src/hostPlugin.ts"],
+      }),
+    );
+    expect(cfg.entry).toEqual(["src/index.ts", "src/hostPlugin.ts"]);
   });
 
   it("supports multi-target overrides as an array", () => {

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  BUNDLE_EVERYTHING_REGEX,
   defineLvisPluginConfig,
   HOST_EXTERNAL_MODULES,
   HOST_BROWSER_EXTERNAL_MODULES,
@@ -19,6 +20,15 @@ function asArray(cfg: ReturnType<typeof defineLvisPluginConfig>) {
   return cfg;
 }
 
+function noExternalRegexes(cfg: { noExternal?: unknown }): RegExp[] {
+  expect(Array.isArray(cfg.noExternal)).toBe(true);
+  const arr = cfg.noExternal as unknown[];
+  for (const item of arr) {
+    expect(item).toBeInstanceOf(RegExp);
+  }
+  return arr as RegExp[];
+}
+
 describe("defineLvisPluginConfig", () => {
   it("emits self-containment defaults when called with no overrides", () => {
     const cfg = asSingle(defineLvisPluginConfig());
@@ -31,10 +41,7 @@ describe("defineLvisPluginConfig", () => {
     expect(cfg.splitting).toBe(false);
     expect(cfg.sourcemap).toBe(true);
     expect(cfg.external).toEqual(["electron"]);
-    // noExternal must contain a regex matching all packages.
-    expect(Array.isArray(cfg.noExternal)).toBe(true);
-    const noExternal = cfg.noExternal as RegExp[];
-    expect(noExternal[0]).toBeInstanceOf(RegExp);
+    const noExternal = noExternalRegexes(cfg);
     expect("node-ical").toMatch(noExternal[0]);
     expect("@azure/msal-node").toMatch(noExternal[0]);
   });
@@ -43,6 +50,11 @@ describe("defineLvisPluginConfig", () => {
     const cfg = asSingle(defineLvisPluginConfig({ external: ["foo"] }));
     expect(cfg.external).toContain("electron");
     expect(cfg.external).toContain("foo");
+  });
+
+  it("ignores attempt to clear host externals via empty external array", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ external: [] }));
+    expect(cfg.external).toEqual(["electron"]);
   });
 
   it("dedupes string externals", () => {
@@ -54,7 +66,18 @@ describe("defineLvisPluginConfig", () => {
     expect(externals.filter((x) => x === "foo")).toHaveLength(1);
   });
 
-  it("auto-adds react/react-dom externals for browser-platform builds", () => {
+  it("dedupes regex externals by source + flags", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ external: [/^node:/, /^node:/, /^node:/i] }),
+    );
+    const regexExternals = (cfg.external as (string | RegExp)[]).filter(
+      (x): x is RegExp => x instanceof RegExp,
+    );
+    // Same source/flags collapsed; different flags preserved.
+    expect(regexExternals).toHaveLength(2);
+  });
+
+  it("auto-adds react/react-dom externals for platform=browser", () => {
     const cfg = asSingle(
       defineLvisPluginConfig({
         platform: "browser",
@@ -66,10 +89,33 @@ describe("defineLvisPluginConfig", () => {
     expect(cfg.external).toContain("react-dom");
   });
 
-  it("does NOT add browser externals for node-platform builds", () => {
+  it("auto-detects browser build via target=es* even without platform field", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        target: "es2020",
+        entry: { "ui/panel": "src/ui/panel.ts" },
+      }),
+    );
+    expect(cfg.external).toContain("react");
+    expect(cfg.external).toContain("react-dom");
+  });
+
+  it("auto-detects browser build via target=chrome*", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ target: "chrome120" }));
+    expect(cfg.external).toContain("react");
+  });
+
+  it("treats node-prefixed targets as node builds", () => {
     const cfg = asSingle(defineLvisPluginConfig({ target: "node18" }));
     expect(cfg.external).not.toContain("react");
     expect(cfg.external).not.toContain("react-dom");
+  });
+
+  it("respects platform=node override even with es target", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ target: "es2020", platform: "node" }),
+    );
+    expect(cfg.external).not.toContain("react");
   });
 
   it("supports multi-target overrides as an array", () => {
@@ -86,17 +132,45 @@ describe("defineLvisPluginConfig", () => {
     );
     expect(cfgs).toHaveLength(2);
     expect(cfgs[0].external).toEqual(["electron"]);
-    expect(cfgs[0].clean).toBe(true); // default preserved
+    expect(cfgs[0].clean).toBe(true);
     expect(cfgs[1].external).toContain("react");
-    expect(cfgs[1].clean).toBe(false); // override wins
+    expect(cfgs[1].external).toContain("react-dom");
+    expect(cfgs[1].clean).toBe(false);
     expect(cfgs[1].target).toBe("es2020");
   });
 
-  it("respects user-provided noExternal override", () => {
+  it("forces noExternal — user override is ignored (contract lock)", () => {
     const cfg = asSingle(
       defineLvisPluginConfig({ noExternal: ["only-this"] }),
     );
-    expect(cfg.noExternal).toEqual(["only-this"]);
+    const noExternal = noExternalRegexes(cfg);
+    expect(noExternal[0].source).toBe(BUNDLE_EVERYTHING_REGEX.source);
+    // Sanity check: the regex matches typical plugin deps.
+    expect("@azure/msal-node").toMatch(noExternal[0]);
+    expect("chokidar").toMatch(noExternal[0]);
+  });
+
+  it("rejects empty noExternal override (contract lock)", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ noExternal: [] }));
+    const noExternal = noExternalRegexes(cfg);
+    expect(noExternal).toHaveLength(1);
+    expect(noExternal[0].source).toBe(BUNDLE_EVERYTHING_REGEX.source);
+  });
+
+  it("allows user to externalize optional native deps without breaking host externals", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        external: ["fsevents", "bufferutil", "utf-8-validate"],
+      }),
+    );
+    expect(cfg.external).toContain("electron");
+    expect(cfg.external).toContain("fsevents");
+    expect(cfg.external).toContain("bufferutil");
+    expect(cfg.external).toContain("utf-8-validate");
+    // noExternal regex would have matched these; but `external` takes
+    // precedence in tsup/esbuild, so they stay external as requested.
+    const noExternal = noExternalRegexes(cfg);
+    expect("fsevents").toMatch(noExternal[0]); // matches but external wins
   });
 
   it("exposes HOST_EXTERNAL_MODULES contract", () => {
@@ -106,5 +180,12 @@ describe("defineLvisPluginConfig", () => {
   it("exposes HOST_BROWSER_EXTERNAL_MODULES contract", () => {
     expect(HOST_BROWSER_EXTERNAL_MODULES).toContain("react");
     expect(HOST_BROWSER_EXTERNAL_MODULES).toContain("react-dom");
+  });
+
+  it("BUNDLE_EVERYTHING_REGEX matches all package-name shapes", () => {
+    expect("foo").toMatch(BUNDLE_EVERYTHING_REGEX);
+    expect("@scope/foo").toMatch(BUNDLE_EVERYTHING_REGEX);
+    expect("foo/sub/path").toMatch(BUNDLE_EVERYTHING_REGEX);
+    expect("foo-bar_baz").toMatch(BUNDLE_EVERYTHING_REGEX);
   });
 });

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  defineLvisPluginConfig,
+  HOST_EXTERNAL_MODULES,
+  HOST_BROWSER_EXTERNAL_MODULES,
+} from "../tsup.js";
+
+function asSingle(cfg: ReturnType<typeof defineLvisPluginConfig>) {
+  if (Array.isArray(cfg)) {
+    throw new Error("expected single-target config");
+  }
+  return cfg;
+}
+
+function asArray(cfg: ReturnType<typeof defineLvisPluginConfig>) {
+  if (!Array.isArray(cfg)) {
+    throw new Error("expected multi-target config");
+  }
+  return cfg;
+}
+
+describe("defineLvisPluginConfig", () => {
+  it("emits self-containment defaults when called with no overrides", () => {
+    const cfg = asSingle(defineLvisPluginConfig());
+    expect(cfg.entry).toEqual(["src/index.ts", "src/hostPlugin.ts"]);
+    expect(cfg.format).toEqual(["esm"]);
+    expect(cfg.target).toBe("node20");
+    expect(cfg.outDir).toBe("dist");
+    expect(cfg.dts).toBe(false);
+    expect(cfg.clean).toBe(true);
+    expect(cfg.splitting).toBe(false);
+    expect(cfg.sourcemap).toBe(true);
+    expect(cfg.external).toEqual(["electron"]);
+    // noExternal must contain a regex matching all packages.
+    expect(Array.isArray(cfg.noExternal)).toBe(true);
+    const noExternal = cfg.noExternal as RegExp[];
+    expect(noExternal[0]).toBeInstanceOf(RegExp);
+    expect("node-ical").toMatch(noExternal[0]);
+    expect("@azure/msal-node").toMatch(noExternal[0]);
+  });
+
+  it("merges user external with host externals (cannot opt out of electron)", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ external: ["foo"] }));
+    expect(cfg.external).toContain("electron");
+    expect(cfg.external).toContain("foo");
+  });
+
+  it("dedupes string externals", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ external: ["electron", "foo", "foo"] }),
+    );
+    const externals = cfg.external as string[];
+    expect(externals.filter((x) => x === "electron")).toHaveLength(1);
+    expect(externals.filter((x) => x === "foo")).toHaveLength(1);
+  });
+
+  it("auto-adds react/react-dom externals for browser-platform builds", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        platform: "browser",
+        entry: { "ui/panel": "src/ui/panel.ts" },
+      }),
+    );
+    expect(cfg.external).toContain("electron");
+    expect(cfg.external).toContain("react");
+    expect(cfg.external).toContain("react-dom");
+  });
+
+  it("does NOT add browser externals for node-platform builds", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ target: "node18" }));
+    expect(cfg.external).not.toContain("react");
+    expect(cfg.external).not.toContain("react-dom");
+  });
+
+  it("supports multi-target overrides as an array", () => {
+    const cfgs = asArray(
+      defineLvisPluginConfig([
+        { entry: ["src/hostPlugin.ts"] },
+        {
+          entry: { "ui/panel": "src/ui/panel.ts" },
+          platform: "browser",
+          target: "es2020",
+          clean: false,
+        },
+      ]),
+    );
+    expect(cfgs).toHaveLength(2);
+    expect(cfgs[0].external).toEqual(["electron"]);
+    expect(cfgs[0].clean).toBe(true); // default preserved
+    expect(cfgs[1].external).toContain("react");
+    expect(cfgs[1].clean).toBe(false); // override wins
+    expect(cfgs[1].target).toBe("es2020");
+  });
+
+  it("respects user-provided noExternal override", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({ noExternal: ["only-this"] }),
+    );
+    expect(cfg.noExternal).toEqual(["only-this"]);
+  });
+
+  it("exposes HOST_EXTERNAL_MODULES contract", () => {
+    expect(HOST_EXTERNAL_MODULES).toContain("electron");
+  });
+
+  it("exposes HOST_BROWSER_EXTERNAL_MODULES contract", () => {
+    expect(HOST_BROWSER_EXTERNAL_MODULES).toContain("react");
+    expect(HOST_BROWSER_EXTERNAL_MODULES).toContain("react-dom");
+  });
+});

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -89,15 +89,15 @@ describe("defineLvisPluginConfig", () => {
     expect(cfg.external).toContain("react-dom");
   });
 
-  it("auto-detects browser build via target=es* even without platform field", () => {
+  it("does NOT auto-detect browser via target=es* (common for Node builds too)", () => {
     const cfg = asSingle(
       defineLvisPluginConfig({
         target: "es2020",
         entry: { "ui/panel": "src/ui/panel.ts" },
       }),
     );
-    expect(cfg.external).toContain("react");
-    expect(cfg.external).toContain("react-dom");
+    expect(cfg.external).not.toContain("react");
+    expect(cfg.external).not.toContain("react-dom");
   });
 
   it("auto-detects browser build via target=chrome*", () => {

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -26,6 +26,17 @@ export const HOST_EXTERNAL_MODULES = ["electron"] as const;
 export const HOST_BROWSER_EXTERNAL_MODULES = ["react", "react-dom"] as const;
 
 /**
+ * The match-everything regex used as the helper's `noExternal` value.
+ *
+ * Exposed so plugin tests can assert that a given dependency name would
+ * be matched (and therefore bundled) by the helper-produced config.
+ */
+// JSDoc cannot embed `*` followed by `/` inside a `/_*_ ... _*_/` block
+// without prematurely terminating the comment, so the regex literal is
+// constructed via the RegExp constructor.
+export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
+
+/**
  * Build a tsup configuration for an LVIS marketplace plugin.
  *
  * ## Self-contained plugin contract
@@ -39,10 +50,11 @@ export const HOST_BROWSER_EXTERNAL_MODULES = ["react", "react-dom"] as const;
  * Therefore: every runtime dependency MUST be bundled into `dist/`.
  *
  * This helper enforces the contract via:
- * - `external: HOST_EXTERNAL_MODULES` (and `HOST_BROWSER_EXTERNAL_MODULES`
- *   when `platform === "browser"`) — host-provided modules stay external.
- * - `noExternal: [match-everything regex]` — every other import (deps,
- *   devDeps, transitive) gets bundled into `dist/`.
+ * - `external: HOST_EXTERNAL_MODULES` (+ HOST_BROWSER_EXTERNAL_MODULES
+ *   for browser builds) — host-provided modules stay external.
+ * - `noExternal: BUNDLE_EVERYTHING_REGEX` — every other import (deps,
+ *   devDeps, transitive) gets bundled into `dist/`. This field is NOT
+ *   overridable: the contract is the helper's reason to exist.
  *
  * ## Defaults
  *
@@ -57,13 +69,44 @@ export const HOST_BROWSER_EXTERNAL_MODULES = ["react", "react-dom"] as const;
  *   under TypeScript 6).
  * - `outDir`: `"dist"`
  * - `external`: HOST_EXTERNAL_MODULES (+ HOST_BROWSER_EXTERNAL_MODULES
- *   when `platform === "browser"`)
- * - `noExternal`: match-everything regex
+ *   when the build is browser-targeted — see below).
+ * - `noExternal`: BUNDLE_EVERYTHING_REGEX (forced, not overridable).
  *
- * Any default can be overridden by passing `overrides`. The `external`
- * array is always merged with the host externals so the contract cannot
- * be silently broken — passing `external: []` does NOT clear the host
- * externals.
+ * Any other default can be overridden via the `overrides` argument. The
+ * `external` array is always merged with the host externals so the
+ * contract cannot be silently bypassed — passing `external: []` does
+ * NOT clear the host externals.
+ *
+ * ## Browser-build detection
+ *
+ * A target is considered a browser build when ANY of the following hold:
+ * - `platform === "browser"`
+ * - `target` is a string starting with `"es"` (e.g., `es2020`, `es2022`)
+ * - `target` is `"chrome*"` / `"firefox*"` / `"safari*"` / `"edge*"`
+ *
+ * This catches the common case where a plugin author specifies an ES /
+ * browser target without explicitly setting `platform: "browser"`. To
+ * opt out, set `platform: "node"` explicitly.
+ *
+ * ## Optional native dependencies
+ *
+ * `noExternal: BUNDLE_EVERYTHING_REGEX` follows ALL imports including
+ * `optionalDependencies` (e.g., `chokidar` → `fsevents` on macOS,
+ * `ws` → `bufferutil`/`utf-8-validate`). esbuild errors when a referenced
+ * optional dep is not installed (typical on cross-platform CI).
+ *
+ * If your plugin transitively pulls in optional native deps, add them to
+ * `external` explicitly:
+ *
+ * ```ts
+ * defineLvisPluginConfig({
+ *   external: ["fsevents", "bufferutil", "utf-8-validate"],
+ * });
+ * ```
+ *
+ * The host's plugin loader will still resolve these against the consumer
+ * machine's optional installs — they're treated as best-effort enhancements,
+ * not hard requirements.
  *
  * ## Usage
  *
@@ -89,7 +132,6 @@ export const HOST_BROWSER_EXTERNAL_MODULES = ["react", "react-dom"] as const;
  *   {
  *     entry: { "ui/panel": "src/ui/panel.ts" },
  *     target: "es2020",
- *     platform: "browser",
  *     clean: false,
  *   },
  * ]);
@@ -104,8 +146,26 @@ export function defineLvisPluginConfig(
   return applyDefaults(overrides);
 }
 
+function isBrowserBuild(override: Options): boolean {
+  if (override.platform === "browser") return true;
+  if (override.platform === "node") return false;
+  const target = override.target;
+  if (typeof target !== "string") return false;
+  const lower = target.toLowerCase();
+  if (lower.startsWith("es")) return true;
+  if (
+    lower.startsWith("chrome") ||
+    lower.startsWith("firefox") ||
+    lower.startsWith("safari") ||
+    lower.startsWith("edge")
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function applyDefaults(override: Options): Options {
-  const isBrowser = override.platform === "browser";
+  const isBrowser = isBrowserBuild(override);
   const hostExternals: (string | RegExp)[] = isBrowser
     ? [...HOST_EXTERNAL_MODULES, ...HOST_BROWSER_EXTERNAL_MODULES]
     : [...HOST_EXTERNAL_MODULES];
@@ -119,7 +179,6 @@ function applyDefaults(override: Options): Options {
     splitting: false,
     dts: false,
     outDir: "dist",
-    noExternal: [/.*/],
   };
 
   const userExternals: (string | RegExp)[] = Array.isArray(override.external)
@@ -130,17 +189,25 @@ function applyDefaults(override: Options): Options {
     ...baseDefaults,
     ...override,
     external: dedupeExternals([...hostExternals, ...userExternals]),
-    noExternal: override.noExternal ?? baseDefaults.noExternal,
+    // noExternal is contract-locked: the helper exists to enforce
+    // self-containment. User overrides for noExternal are intentionally
+    // ignored.
+    noExternal: [BUNDLE_EVERYTHING_REGEX],
   };
 }
 
 function dedupeExternals(items: (string | RegExp)[]): (string | RegExp)[] {
   const seenStrings = new Set<string>();
+  const seenRegexSources = new Set<string>();
   const out: (string | RegExp)[] = [];
   for (const item of items) {
     if (typeof item === "string") {
       if (seenStrings.has(item)) continue;
       seenStrings.add(item);
+    } else if (item instanceof RegExp) {
+      const key = `${item.source}/${item.flags}`;
+      if (seenRegexSources.has(key)) continue;
+      seenRegexSources.add(key);
     }
     out.push(item);
   }

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -52,13 +52,16 @@ export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
  * This helper enforces the contract via:
  * - `external: HOST_EXTERNAL_MODULES` (+ HOST_BROWSER_EXTERNAL_MODULES
  *   for browser builds) — host-provided modules stay external.
- * - `noExternal: BUNDLE_EVERYTHING_REGEX` — every other import (deps,
+ * - `noExternal: [BUNDLE_EVERYTHING_REGEX]` — every other import (deps,
  *   devDeps, transitive) gets bundled into `dist/`. This field is NOT
  *   overridable: the contract is the helper's reason to exist.
  *
  * ## Defaults
  *
- * - `entry`: `["src/index.ts", "src/hostPlugin.ts"]`
+ * - `entry`: `["src/hostPlugin.ts"]` — the marketplace contract entry
+ *   referenced by `plugin.json`. Plugins that also publish a separate
+ *   `src/index.ts` for npm-package consumption should override:
+ *   `entry: ["src/index.ts", "src/hostPlugin.ts"]`.
  * - `format`: `["esm"]`
  * - `target`: `"node20"`
  * - `clean`: `true`
@@ -70,7 +73,7 @@ export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
  * - `outDir`: `"dist"`
  * - `external`: HOST_EXTERNAL_MODULES (+ HOST_BROWSER_EXTERNAL_MODULES
  *   when the build is browser-targeted — see below).
- * - `noExternal`: BUNDLE_EVERYTHING_REGEX (forced, not overridable).
+ * - `noExternal`: `[BUNDLE_EVERYTHING_REGEX]` (forced, not overridable).
  *
  * Any other default can be overridden via the `overrides` argument. The
  * `external` array is always merged with the host externals so the
@@ -149,19 +152,27 @@ export function defineLvisPluginConfig(
 function isBrowserBuild(override: Options): boolean {
   if (override.platform === "browser") return true;
   if (override.platform === "node") return false;
-  const target = override.target;
+  // tsup `target` is `string | string[] | undefined`. Treat any element
+  // that looks like a browser target as evidence of a browser build.
+  const targets =
+    typeof override.target === "string"
+      ? [override.target]
+      : Array.isArray(override.target)
+      ? override.target
+      : [];
+  return targets.some((t) => looksLikeBrowserTarget(t));
+}
+
+function looksLikeBrowserTarget(target: unknown): boolean {
   if (typeof target !== "string") return false;
   const lower = target.toLowerCase();
   if (lower.startsWith("es")) return true;
-  if (
+  return (
     lower.startsWith("chrome") ||
     lower.startsWith("firefox") ||
     lower.startsWith("safari") ||
     lower.startsWith("edge")
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 function applyDefaults(override: Options): Options {
@@ -171,7 +182,11 @@ function applyDefaults(override: Options): Options {
     : [...HOST_EXTERNAL_MODULES];
 
   const baseDefaults: Options = {
-    entry: ["src/index.ts", "src/hostPlugin.ts"],
+    // The marketplace contract entry is `src/hostPlugin.ts` — `plugin.json`
+    // points at `dist/hostPlugin.js`. Plugins that ALSO ship a separate
+    // `src/index.ts` (e.g., for npm-package consumption) should override
+    // `entry` explicitly: `entry: ["src/index.ts", "src/hostPlugin.ts"]`.
+    entry: ["src/hostPlugin.ts"],
     format: ["esm"],
     target: "node20",
     clean: true,

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -1,0 +1,148 @@
+import type { Options } from "tsup";
+
+/**
+ * Modules treated as external by the LVIS host runtime.
+ *
+ * Marketplace plugins MUST NOT bundle these — they are provided by the
+ * host process at plugin-load time. Bundling them would create duplicate
+ * runtime instances (e.g., two `electron` contexts) and break IPC.
+ *
+ * This list is the SDK ↔ host contract. When the host adds a new
+ * injected module, SDK MAJOR is bumped and this list is updated; plugins
+ * pinned to an older SDK version continue using the older contract,
+ * which means the new module gets bundled redundantly — harmless, just a
+ * larger zip.
+ */
+export const HOST_EXTERNAL_MODULES = ["electron"] as const;
+
+/**
+ * Additional modules treated as external for browser-target plugin
+ * bundles (UI panels rendered inside the host renderer process).
+ *
+ * `react` / `react-dom` MUST come from the host's React context — if a
+ * plugin's UI bundle ships its own copy, you get two React instances and
+ * the React context API silently fails (provider/consumer mismatch).
+ */
+export const HOST_BROWSER_EXTERNAL_MODULES = ["react", "react-dom"] as const;
+
+/**
+ * Build a tsup configuration for an LVIS marketplace plugin.
+ *
+ * ## Self-contained plugin contract
+ *
+ * LVIS marketplace plugins are distributed as zip archives that contain
+ * ONLY `dist/` and `plugin.json`. The publish workflow excludes
+ * `node_modules/` from the zip, and the host plugin loader uses strict
+ * `pluginRoot` containment (no sibling-repo escape since 2026-05). So
+ * plugins cannot fall back to the host's `node_modules/` at runtime.
+ *
+ * Therefore: every runtime dependency MUST be bundled into `dist/`.
+ *
+ * This helper enforces the contract via:
+ * - `external: HOST_EXTERNAL_MODULES` (and `HOST_BROWSER_EXTERNAL_MODULES`
+ *   when `platform === "browser"`) — host-provided modules stay external.
+ * - `noExternal: [match-everything regex]` — every other import (deps,
+ *   devDeps, transitive) gets bundled into `dist/`.
+ *
+ * ## Defaults
+ *
+ * - `entry`: `["src/index.ts", "src/hostPlugin.ts"]`
+ * - `format`: `["esm"]`
+ * - `target`: `"node20"`
+ * - `clean`: `true`
+ * - `sourcemap`: `true`
+ * - `splitting`: `false`
+ * - `dts`: `false` (use `tsc --emitDeclarationOnly` separately —
+ *   tsup v8.5.x injects a hardcoded `baseUrl: "."` that triggers TS5101
+ *   under TypeScript 6).
+ * - `outDir`: `"dist"`
+ * - `external`: HOST_EXTERNAL_MODULES (+ HOST_BROWSER_EXTERNAL_MODULES
+ *   when `platform === "browser"`)
+ * - `noExternal`: match-everything regex
+ *
+ * Any default can be overridden by passing `overrides`. The `external`
+ * array is always merged with the host externals so the contract cannot
+ * be silently broken — passing `external: []` does NOT clear the host
+ * externals.
+ *
+ * ## Usage
+ *
+ * Single-target (most plugins):
+ * ```ts
+ * import { defineLvisPluginConfig } from "@lvis/plugin-sdk/build";
+ * export default defineLvisPluginConfig();
+ * ```
+ *
+ * Override defaults:
+ * ```ts
+ * export default defineLvisPluginConfig({
+ *   entry: ["src/main.ts"],
+ *   target: "node18",
+ *   format: ["esm", "cjs"],
+ * });
+ * ```
+ *
+ * Multi-target (host + browser UI):
+ * ```ts
+ * export default defineLvisPluginConfig([
+ *   { entry: ["src/hostPlugin.ts"] },
+ *   {
+ *     entry: { "ui/panel": "src/ui/panel.ts" },
+ *     target: "es2020",
+ *     platform: "browser",
+ *     clean: false,
+ *   },
+ * ]);
+ * ```
+ */
+export function defineLvisPluginConfig(
+  overrides: Options | Options[] = {},
+): Options | Options[] {
+  if (Array.isArray(overrides)) {
+    return overrides.map(applyDefaults);
+  }
+  return applyDefaults(overrides);
+}
+
+function applyDefaults(override: Options): Options {
+  const isBrowser = override.platform === "browser";
+  const hostExternals: (string | RegExp)[] = isBrowser
+    ? [...HOST_EXTERNAL_MODULES, ...HOST_BROWSER_EXTERNAL_MODULES]
+    : [...HOST_EXTERNAL_MODULES];
+
+  const baseDefaults: Options = {
+    entry: ["src/index.ts", "src/hostPlugin.ts"],
+    format: ["esm"],
+    target: "node20",
+    clean: true,
+    sourcemap: true,
+    splitting: false,
+    dts: false,
+    outDir: "dist",
+    noExternal: [/.*/],
+  };
+
+  const userExternals: (string | RegExp)[] = Array.isArray(override.external)
+    ? override.external
+    : [];
+
+  return {
+    ...baseDefaults,
+    ...override,
+    external: dedupeExternals([...hostExternals, ...userExternals]),
+    noExternal: override.noExternal ?? baseDefaults.noExternal,
+  };
+}
+
+function dedupeExternals(items: (string | RegExp)[]): (string | RegExp)[] {
+  const seenStrings = new Set<string>();
+  const out: (string | RegExp)[] = [];
+  for (const item of items) {
+    if (typeof item === "string") {
+      if (seenStrings.has(item)) continue;
+      seenStrings.add(item);
+    }
+    out.push(item);
+  }
+  return out;
+}

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -95,7 +95,7 @@ export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
  *
  * ## Optional native dependencies
  *
- * `noExternal: BUNDLE_EVERYTHING_REGEX` follows ALL imports including
+ * `noExternal: [BUNDLE_EVERYTHING_REGEX]` follows ALL imports including
  * `optionalDependencies` (e.g., `chokidar` → `fsevents` on macOS,
  * `ws` → `bufferutil`/`utf-8-validate`). esbuild errors when a referenced
  * optional dep is not installed (typical on cross-platform CI).
@@ -130,12 +130,16 @@ export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
  * });
  * ```
  *
- * Multi-target (host + browser UI):
+ * Multi-target (host + browser UI). The browser entry must set
+ * `platform: "browser"` explicitly so the helper auto-adds
+ * `react` / `react-dom` to `external` (otherwise React would be bundled
+ * twice, breaking the host's React context):
  * ```ts
  * export default defineLvisPluginConfig([
  *   { entry: ["src/hostPlugin.ts"] },
  *   {
  *     entry: { "ui/panel": "src/ui/panel.ts" },
+ *     platform: "browser",
  *     target: "es2020",
  *     clean: false,
  *   },

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -84,12 +84,14 @@ export const BUNDLE_EVERYTHING_REGEX = new RegExp(".*");
  *
  * A target is considered a browser build when ANY of the following hold:
  * - `platform === "browser"`
- * - `target` is a string starting with `"es"` (e.g., `es2020`, `es2022`)
  * - `target` is `"chrome*"` / `"firefox*"` / `"safari*"` / `"edge*"`
+ *   (case-insensitive). Array targets are checked element-wise.
  *
- * This catches the common case where a plugin author specifies an ES /
- * browser target without explicitly setting `platform: "browser"`. To
- * opt out, set `platform: "node"` explicitly.
+ * `target: "es2020"` / `"es2022"` is NOT auto-detected as browser:
+ * those targets are commonly used for modern Node builds too, and
+ * silently adding `react` / `react-dom` externals to a Node build that
+ * imports React would break runtime resolution. For browser UI bundles,
+ * set `platform: "browser"` explicitly.
  *
  * ## Optional native dependencies
  *
@@ -166,7 +168,12 @@ function isBrowserBuild(override: Options): boolean {
 function looksLikeBrowserTarget(target: unknown): boolean {
   if (typeof target !== "string") return false;
   const lower = target.toLowerCase();
-  if (lower.startsWith("es")) return true;
+  // ES targets (es2020 / es2022) are intentionally excluded — they are
+  // commonly used for modern Node builds too, and auto-adding react /
+  // react-dom externals on a Node build that happens to import React
+  // would silently break runtime resolution. Only browser-vendor target
+  // names are unambiguous enough to auto-detect; for any other case the
+  // plugin author should set `platform: "browser"` explicitly.
   return (
     lower.startsWith("chrome") ||
     lower.startsWith("firefox") ||

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
     "index": "src/index.ts",
     "ui/index": "src/ui/index.ts",
     "ui/tokens/index": "src/ui/tokens/index.ts",
+    "build/tsup": "src/build/tsup.ts",
   },
   format: ["esm"],
   // dts emission is delegated to `tsc -p tsconfig.build.json` (see package.json
@@ -12,5 +13,7 @@ export default defineConfig({
   // tsc directly avoids that code path entirely.
   dts: false,
   clean: true,
-  external: ["react", "react-dom"],
+  // `tsup` is a peer/dev concern of consumers, not the SDK runtime — keep it
+  // external so `@lvis/plugin-sdk/build` doesn't drag the tsup runtime in.
+  external: ["react", "react-dom", "tsup"],
 });


### PR DESCRIPTION
## Summary

- 외부 플러그인 개발자가 호스트 내부를 모르고도 올바른 빌드를 자동으로 얻을 수 있는 SDK build helper 추가
- `@lvis/plugin-sdk/build` 의 `defineLvisPluginConfig()` 가 self-containment 약속을 단일 출처로 인코딩 (`external: HOST_EXTERNAL_MODULES`, `noExternal: [match-all regex]`)
- ms-graph 의 \`Cannot find package 'node-ical'\` 설치 실패의 architectural 원인 해결 — 모든 마켓플레이스 플러그인에 동일한 self-containment 패턴 적용 가능

## 배경 — Why this exists

마켓플레이스 플러그인은 zip 으로 배포되며 publish 워크플로우는 \`node_modules/\` 를 의도적으로 제외한다. 호스트 플러그인 로더는 2026-05 부터 strict pluginRoot containment 을 적용 (sibling-repo escape 제거됨) — 따라서 플러그인은 모든 런타임 의존성을 \`dist/\` 에 self-contain 해야 한다.

그러나 plugin tsup config 들은 이 변경에 맞춰 업데이트되지 않았고, tsup 의 기본 동작 (\`dependencies\` 자동 external) 으로 인해 dist 에는 raw \`import\` 문만 남는 상태로 zip 됨. ms-graph 가 \`node-ical\`, \`@azure/msal-node\` 두 deps 로 가장 먼저 터졌고, pageindex 의 \`chokidar\` 도 잠재 폭탄 상태.

외부 개발자는 lvis-app 소스를 보지 못하므로 어떤 패키지가 호스트에 있고 어떤 게 없는지 알 수 없다. SDK 가 contract 를 단일 출처로 관리해야 한다.

## 변경사항

- \`src/build/tsup.ts\` 신규 — \`defineLvisPluginConfig()\` + \`HOST_EXTERNAL_MODULES\` + \`HOST_BROWSER_EXTERNAL_MODULES\`
- \`tsup.config.ts\` — 새 entry \`build/tsup\` 추가, tsup 자체는 external (런타임 끌어들이지 않음)
- \`package.json\` — version 3.3.0 → 3.4.0, \`./build\` subpath export (TS source 직접 참조 — tsup jiti 가 로드)
- \`src/build/__tests__/tsup.test.ts\` — helper contract 9 케이스 (defaults, external merge, dedupe, browser auto-externals, multi-target array, noExternal override 등)

## Helper 사용 예 (외부 개발자 관점)

\`\`\`ts
// lvis-plugin-foo/tsup.config.ts
import { defineLvisPluginConfig } from "@lvis/plugin-sdk/build";

export default defineLvisPluginConfig();
\`\`\`

오버라이드 가능, multi-target (host + browser UI) array 지원, browser-platform 자동 \`react/react-dom\` external.

## Test plan

- [x] \`bun run build\` — 5 entries 빌드 성공 (\`dist/build/tsup.js\` 1.36 KB)
- [x] \`bunx vitest run\` — 120 tests 통과 (기존 111 + 신규 9)
- [x] \`bunx tsc --noEmit\` — 0 에러
- [ ] (후속 PR) 6 active 플러그인 + template 가 helper 사용하도록 마이그레이션

## Migration roadmap

이 PR 머지 + \`v3.4.0\` 태그 후, 각 플러그인의 후속 PR:
1. \`devDependencies['@lvis/plugin-sdk']\` → \`v3.4.0\`
2. \`tsup.config.ts\` → \`defineLvisPluginConfig()\` 호출로 단순화
3. \`plugin.json\` version bump → 마켓플레이스 재배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)