### PR TITLE
chore: ChatTheme union 에 "lg" 추가 — host PR #497 컴패니언

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/src/ui/tokens/index.ts
+++ b/src/ui/tokens/index.ts
@@ -13,7 +13,7 @@ export type LvisThemeTokens = {
 
 export type LvisThemePayload = {
   theme: "light" | "dark" | "high-contrast";
-  chatTheme: "default" | "purple" | "orange" | "blue";
+  chatTheme: "default" | "lg" | "purple" | "orange" | "blue";
   codeTheme: "light" | "dark";
   /** Optional explicit token values. When absent, CSS data-theme selectors handle theming. */
   tokens?: Partial<LvisThemeTokens>;


### PR DESCRIPTION
## 컴패니언 PR

lvis-app **PR #497** (`feat(theme): split LG brand identity into dedicated chat-theme="lg"`) 의 lockstep 컴패니언.

## 배경

lvis-app 호스트가 새 chat-theme `"lg"` 를 추가했음 (LG 브랜드 정체성 — warm-grey 표면 + 라일락 버블 + vivid SEND + LG red). `feedback-host-plugin-contract-sync` 룰에 따라 SDK 의 published 타입도 같이 갱신.

호스트가 `chatTheme: "lg"` 를 plugin webview 로 emit (via `notifyPluginTheme` IPC, PR #489) 하면, SDK `LvisThemePayload.chatTheme` 가 closed union (`"default"|"purple"|"orange"|"blue"`) 라 plugin TS consumer 가 type error. SDK union 에 `"lg"` 추가.

## 변경 내용

- `src/ui/tokens/index.ts:16` — `LvisThemePayload.chatTheme` union 에 `"lg"` 추가:
  ```diff
  -  chatTheme: "default" | "purple" | "orange" | "blue";
  +  chatTheme: "default" | "lg" | "purple" | "orange" | "blue";
  ```
- `package.json` — minor bump `3.3.0` → `3.4.0`. 추가형 type widening 으로 기존 variant 만 switch 하는 plugin 은 영향 없음 (backwards-compatible).

## 영향

- 현 plugin 중 chatTheme literal 에 `switch`/`case` 하는 곳: **0** (audit 확인).
- SDK 사용자 (plugin developer) 는 새 SDK 버전으로 업그레이드하면 `"lg"` 를 narrow 가능.
- 호스트 PR #497 은 본 PR 머지 후 `@lvis/plugin-sdk` 의존성을 `v3.4.0` 으로 bump 해서 lockstep 유지.

## 검증

- `bun run build`: tsup + tsc 빌드 clean
- `bun run test`: 111/111 tests pass

## 머지 순서 권장

1. **본 PR (SDK v3.4.0)** 머지 → tag/release
2. lvis-app **PR #497** 의 `package.json` 에서 `@lvis/plugin-sdk` 버전을 `v3.4.0` 으로 bump → 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)