### PR TITLE
fix(sdk): drop tsc from prepare — fixes github: install for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
-    "prepare": "tsup && tsc -p tsconfig.build.json",
+    "prepare": "tsup",
     "dev:storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "sync:from-host": "node scripts/sync-from-host.mjs",


### PR DESCRIPTION
## Summary

v3.4.0 introduced a `prepare` script (`tsup && tsc -p tsconfig.build.json`) so consumers of `github:lvis-project/lvis-plugin-sdk#v3.4.0` get the runtime JS built locally. The `tsc` step compiles all of `src/` including UI components that import `react` — but `react` is in `devDependencies`, which bun does NOT install for transitive github sources. Consumers see:

\`\`\`
src/ui/components/Spinner.tsx(18,68): error TS7026: JSX element implicitly has type 'any'
src/ui/components/Text.tsx(1,19): error TS2307: Cannot find module 'react'
\`\`\`

## Fix

Drop `tsc` from `prepare`. `prepare` now runs only `tsup` which produces all 5 dist ESM entries. Type info for `@lvis/plugin-sdk/build` resolves directly from `./src/build/tsup.ts` per the `exports."./build".types` field — no `.d.ts` in dist needed for that path.

Bumped to 3.4.1 (patch — no API change). v3.4.0 helper users (i.e., the imminent ms-graph migration) need to bump to v3.4.1 to get a working install.

## Test plan

- [x] \`rm -rf dist && bun run prepare\` → 5 ESM entries, including dist/build/tsup.js
- [x] Reproduced original failure on ms-graph local migration; v3.4.1 unblocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)