### PR TITLE
chore: gitignore package-lock.json — bun canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .omc/
 .host/
+package-lock.json


### PR DESCRIPTION
1-line gitignore. Prevent npm/bun drift.