### PR TITLE
fix(build): inject CJS-interop banner — plugin ESM bundles 의 dynamic require crash fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",

--- a/src/build/__tests__/tsup.test.ts
+++ b/src/build/__tests__/tsup.test.ts
@@ -44,6 +44,133 @@ describe("defineLvisPluginConfig", () => {
     const noExternal = noExternalRegexes(cfg);
     expect("node-ical").toMatch(noExternal[0]);
     expect("@azure/msal-node").toMatch(noExternal[0]);
+    // CJS-interop banner is auto-injected on Node builds so esbuild's
+    // dynamic-require shim resolves to a real `require`, and CJS-style
+    // `__filename`/`__dirname` are reconstructed from `import.meta.url`.
+    // Node-target plugins always get this; browser builds opt out.
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("createRequire"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("__filename"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("__dirname"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("import.meta.url"),
+    });
+    // Helpers must use the `__lvis*` prefix so they cannot collide with
+    // user source's own `createRequire` / `fileURLToPath` / `dirname`
+    // imports. A future refactor that drops the prefix would silently
+    // break user code — lock the names in.
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("__lvisCreateRequire"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("__lvisFileURLToPath"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("__lvisDirname"),
+    });
+    // `var` (not `const`) — bundled deps frequently emit their own
+    // `var __filename = ...` preamble; `const` would SyntaxError on
+    // redeclaration. Lock the choice in so a future "modernize to const"
+    // refactor doesn't reintroduce the regression.
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("var __filename"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("var __dirname"),
+    });
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("var require"),
+    });
+  });
+
+  it("preserves user banner.css and prepends CJS-interop to user banner.js (Node build)", () => {
+    // BLOCKER regression — naïve { ...baseDefaults, ...override } would
+    // let a user-supplied `banner: { css: "..." }` wipe our js, silently
+    // re-breaking dynamic require. Verify the merge keeps our js AND
+    // user's css.
+    const userJs = "/* userPrologue */ globalThis.__lvisUserMarker = 1;";
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        banner: {
+          css: "/* user-css */",
+          js: userJs,
+        },
+      }),
+    );
+    expect(cfg.banner).toMatchObject({
+      css: "/* user-css */",
+    });
+    const banner = cfg.banner as { js?: string };
+    expect(banner.js).toContain("createRequire");
+    expect(banner.js).toContain(userJs);
+    // CJS-interop comes BEFORE user js so const require is in scope.
+    expect(banner.js!.indexOf("createRequire")).toBeLessThan(
+      banner.js!.indexOf(userJs),
+    );
+  });
+
+  it("css-only user banner does not silently drop CJS-interop js (BLOCKER regression)", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        banner: { css: "/* css only */" },
+      }),
+    );
+    expect(cfg.banner).toMatchObject({
+      css: "/* css only */",
+      js: expect.stringContaining("createRequire"),
+    });
+  });
+
+  it("explicit `banner: undefined` still gets CJS-interop on Node build", () => {
+    const cfg = asSingle(defineLvisPluginConfig({ banner: undefined }));
+    expect(cfg.banner).toMatchObject({
+      js: expect.stringContaining("createRequire"),
+    });
+  });
+
+  it("function-form user banner is wrapped — wrapper invokes user fn and merges CJS-interop", () => {
+    const userJs = "/* user-fn-js */";
+    const userBannerFn = (ctx: { format: string }) => ({
+      js: `${userJs}/*${ctx.format}*/`,
+    });
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        banner: userBannerFn,
+      }),
+    );
+    // Result must itself be a function so tsup invokes it per format.
+    expect(typeof cfg.banner).toBe("function");
+    const wrapped = cfg.banner as (ctx: { format: string }) => {
+      js?: string;
+      css?: string;
+    };
+    const result = wrapped({ format: "esm" });
+    // CJS-interop is prepended; user's per-format js follows.
+    expect(result.js).toContain("createRequire");
+    expect(result.js).toContain(userJs);
+    expect(result.js).toContain("/*esm*/");
+    expect(result.js!.indexOf("createRequire")).toBeLessThan(
+      result.js!.indexOf(userJs),
+    );
+  });
+
+  it("function-form user banner returning null/undefined still gets CJS-interop", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        banner: () => undefined,
+      }),
+    );
+    const wrapped = cfg.banner as (ctx: { format: string }) => {
+      js?: string;
+      css?: string;
+    };
+    const result = wrapped({ format: "esm" });
+    expect(result.js).toContain("createRequire");
   });
 
   it("merges user external with host externals (cannot opt out of electron)", () => {
@@ -87,6 +214,16 @@ describe("defineLvisPluginConfig", () => {
     expect(cfg.external).toContain("electron");
     expect(cfg.external).toContain("react");
     expect(cfg.external).toContain("react-dom");
+  });
+
+  it("skips the CJS-interop banner on browser builds (no `module` specifier in browsers)", () => {
+    const cfg = asSingle(
+      defineLvisPluginConfig({
+        platform: "browser",
+        entry: { "ui/panel": "src/ui/panel.ts" },
+      }),
+    );
+    expect(cfg.banner).toBeUndefined();
   });
 
   it("does NOT auto-detect browser via target=es* (common for Node builds too)", () => {
@@ -162,6 +299,13 @@ describe("defineLvisPluginConfig", () => {
     expect(cfgs[1].external).toContain("react-dom");
     expect(cfgs[1].clean).toBe(false);
     expect(cfgs[1].target).toBe("es2020");
+    // Per-target banner — Node target gets CJS-interop, browser target
+    // gets nothing (it would otherwise reference unresolvable `module`/
+    // `url`/`path` specifiers in the browser).
+    expect(cfgs[0].banner).toMatchObject({
+      js: expect.stringContaining("createRequire"),
+    });
+    expect(cfgs[1].banner).toBeUndefined();
   });
 
   it("forces noExternal — user override is ignored (contract lock)", () => {

--- a/src/build/tsup.ts
+++ b/src/build/tsup.ts
@@ -211,6 +211,68 @@ function applyDefaults(override: Options): Options {
     ? override.external
     : [];
 
+  // CJS-interop banner — bundled CJS deps in the ESM output need three
+  // CJS globals re-injected so they don't crash at runtime:
+  //   `require`     — esbuild's dynamic-require shim falls back to a
+  //                   throwing Proxy ("Dynamic require of "fs" is not
+  //                   supported") when no real `require` is in scope.
+  //                   `createRequire(import.meta.url)` provides one.
+  //   `__filename`  — referenced by some deps (e.g. parts of
+  //                   `node-ical`, `msal-node`) at module load time.
+  //                   `fileURLToPath(import.meta.url)` reconstructs it.
+  //   `__dirname`   — same — derived from `__filename`.
+  //
+  // Without this banner the ESM output throws on first import.
+  //
+  // Skipped for browser builds: `import.meta.url` and `"module"`/`"url"`/
+  // `"path"` specifiers aren't browser-resolvable. Browser UI bundles
+  // shouldn't pull in Node CJS deps anyway.
+  //
+  // Helper imports are prefixed with `__lvis` so they cannot collide with
+  // user source's own `createRequire`/`fileURLToPath`/`dirname` imports.
+  // The CJS-style identifiers (`require`/`__filename`/`__dirname`) are
+  // intentionally unprefixed because bundled CJS deps reference them by
+  // those exact names.
+  //
+  // `var` (NOT `const`) is critical: bundled deps frequently emit their
+  // own ESM-to-CJS interop preamble like
+  //   var __filename = fileURLToPath(import.meta.url);
+  // — using `const` here would `SyntaxError: Identifier '__filename'
+  // has already been declared`. `var` permits redeclaration (even under
+  // strict mode), so multiple definitions coexist; both compute the
+  // same value so the final binding is correct regardless of order.
+  const cjsInteropJs =
+    'import { createRequire as __lvisCreateRequire } from "module";' +
+    'import { fileURLToPath as __lvisFileURLToPath } from "url";' +
+    'import { dirname as __lvisDirname } from "path";' +
+    "var require = __lvisCreateRequire(import.meta.url);" +
+    "var __filename = __lvisFileURLToPath(import.meta.url);" +
+    "var __dirname = __lvisDirname(__filename);";
+
+  // Banner merge — preserve any user-supplied banner fields (e.g. `css`
+  // for browser UI bundles, or extra `js` prologue) while ALWAYS keeping
+  // our CJS-interop js on Node builds. Naïve `{...baseDefaults, ...override}`
+  // would let `banner: { css: "..." }` silently drop our `js` and reintroduce
+  // the dynamic-require crash — that's the bug this PR fixes, so the merge
+  // here closes the loophole. User's own `js` is appended after ours so the
+  // CJS globals are in scope when user code runs.
+  //
+  // tsup's `Options['banner']` accepts either an object OR a per-format
+  // function `(ctx) => banner | undefined`. Both are handled.
+  const userBanner = override.banner;
+  const mergeWithCjsInterop = (
+    user: { js?: string; css?: string } | undefined,
+  ): { js?: string; css?: string } => ({
+    ...user,
+    js: cjsInteropJs + (user?.js ?? ""),
+  });
+  const mergedBanner = isBrowser
+    ? userBanner
+    : typeof userBanner === "function"
+      ? (ctx: Parameters<Extract<typeof userBanner, (...args: never) => unknown>>[0]) =>
+          mergeWithCjsInterop(userBanner(ctx) || undefined)
+      : mergeWithCjsInterop(userBanner);
+
   return {
     ...baseDefaults,
     ...override,
@@ -219,6 +281,11 @@ function applyDefaults(override: Options): Options {
     // self-containment. User overrides for noExternal are intentionally
     // ignored.
     noExternal: [BUNDLE_EVERYTHING_REGEX],
+    // banner is also contract-locked on Node builds: dropping the
+    // CJS-interop js would re-break dynamic require. We merge instead of
+    // overwrite so legitimate banner overrides (css, extra js prologue)
+    // still work.
+    banner: mergedBanner,
   };
 }
 


### PR DESCRIPTION
## 배경

\`defineLvisPluginConfig\` 가 single ESM 출력 + \`noExternal: [BUNDLE_EVERYTHING_REGEX]\` 로 모든 dep 를 dist/ 에 번들. esbuild 가 CJS deps 의 dynamic \`require()\` 를 런타임 throw 하는 fallback shim 으로 변환:

\`\`\`js
var __require = ((x) => typeof require !== "undefined" ? require : new Proxy(...))(...);
__require("fs"); // throws "Dynamic require of \"fs\" is not supported"
\`\`\`

CJS deps (\`node-ical\`, \`chokidar\`, \`msal-node\`, \`ws\` 등) 는 module load 시점에 \`__filename\`/\`__dirname\` 도 참조 — ESM 환경에선 undefined.

결과: 본 helper 로 빌드된 모든 plugin 이 첫 import 에서 즉사. production 에서 관찰된 케이스:

- \`pageindex@0.1.16\` — \`PageIndex worker exited before becoming healthy\`
- \`ms-graph@0.1.18\` — \`Dynamic require of "fs" is not supported\`
- \`meeting@0.1.19\` — 동일 root cause, latent

(lvis-marketplace#90 의 root cause #1)

## Fix

Node 타겟 출력 최상단에 CJS-interop banner 주입:

\`\`\`js
import { createRequire as __lvisCreateRequire } from "module";
import { fileURLToPath as __lvisFileURLToPath } from "url";
import { dirname as __lvisDirname } from "path";
var require = __lvisCreateRequire(import.meta.url);
var __filename = __lvisFileURLToPath(import.meta.url);
var __dirname = __lvisDirname(__filename);
\`\`\`

이제 esbuild 의 \`__require\` shim 이 \`typeof require !== "undefined"\` 분기에서 real require 를 잡음. bundled deps 는 real \`__filename\`/\`__dirname\` 사용.

### 핵심 디자인 결정

- **\`var\` not \`const\`**: bundled deps 가 자체 \`var __filename = fileURLToPath(import.meta.url)\` preamble emit. \`const\` 면 \`SyntaxError: Identifier '__filename' has already been declared\`. \`var\` 는 redeclaration 허용, 같은 값 재할당이라 안전.
- **Helper imports \`__lvis*\` prefixed**: user source 의 \`createRequire\`/\`fileURLToPath\`/\`dirname\` import 와 충돌 방지.
- **Banner merge (not replace)**: user-supplied \`banner: { css: "..." }\` 또는 function-form banner 보존. 우리 CJS-interop js 가 user js 앞에 prepend. 단순 \`{ ...override }\` 면 css-only override 가 silent 하게 우리 js 떨어뜨려 회귀 — 본 PR 이 fix 하려는 그 버그 자체. function-form (\`(ctx) => ...\`) 도 wrapper 로 동일 의미 보존.
- **Browser builds opt out**: \`isBrowser\` 분기로 banner undefined. \`import.meta.url\`/\`module\`/\`url\`/\`path\` 는 browser-resolvable 아님. browser UI 번들이 Node CJS deps 끌어올 일 자체가 없음.

## 검증

- **149/149 SDK tests pass** (banner 주입 3개 + merge 회귀 4개 신규)
- \`bunx tsc --noEmit\` clean (function-form banner type-narrowing sound)
- **로컬 file:-link smoke (3개 영향 plugin)**:
  - **pageindex** → \`import('./dist/hostPlugin.js')\` exports OK
  - **meeting** → \`import('./dist/hostPlugin.js')\` exports OK (\`PUSH_CHUNK_LIMITS\`, \`PushChunkRateLimiter\`, \`default\`)
  - **ms-graph** → banner line 1 정상 주입 확인 (electron context 필요해 standalone import 한계, host install 시점 검증)
- **Self-review (lvis-static-analyzer 2회)**: 1차 BLOCKER 1 + HIGH 1 + MEDIUM 2 + LOW 1 → 모두 fix → 2차 BLOCKER 0 / HIGH 0 / MEDIUM 0 / LOW 0

## Bump

\`3.4.1\` → \`3.4.2\` (patch — 버그 fix, additive default, user banner override 가 silent drop 안 되니 backwards-compat 강화 방향)

## 후속 (별도 PR)

- **lvis-plugin-pageindex / ms-graph / meeting**: SDK ref \`v3.4.1\` → \`v3.4.2\` bump + version patch bump + 재발행 (Phase 2)
- **plugin CI 에 artifact-load smoke**: 각 plugin repo CI 에 \`node -e "import('./dist/hostPlugin.js')"\` 추가 (Phase 3)
- **lvis-marketplace#90**: alembic-upgrade-postgres failure (Phase 4) — 별개

Closes lvis-marketplace#90 root cause #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)