### PR TITLE
feat(tokens): lvis-tokens.css variant 블록 제거 + Storybook JS 토큰 전환

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react";
 import type { Preview } from "@storybook/react";
 import "../src/ui/tokens/lvis-tokens.css";
+import { applyThemeTokens } from "../src/ui/tokens/inject.js";
+import { resolveStoryTokens } from "./story-token-map.js";
 
 const preview: Preview = {
   decorators: [
@@ -8,12 +10,12 @@ const preview: Preview = {
       const theme = (ctx.globals.theme as string) ?? "dark";
       const chatTheme = (ctx.globals.chatTheme as string) ?? "purple";
       useEffect(() => {
+        // Apply computed token values directly — no longer relies on
+        // data-theme/data-chat-theme CSS selectors in lvis-tokens.css.
+        applyThemeTokens(resolveStoryTokens(theme, chatTheme));
+        // Still set data-theme for debugging / future CSS use.
         document.documentElement.setAttribute("data-theme", theme);
-        if (chatTheme === "default") {
-          document.documentElement.removeAttribute("data-chat-theme");
-        } else {
-          document.documentElement.setAttribute("data-chat-theme", chatTheme);
-        }
+        document.documentElement.removeAttribute("data-chat-theme");
       }, [theme, chatTheme]);
       return (
         <div style={{ padding: "1.5rem", background: "var(--lvis-bg)", minHeight: "100vh" }}>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,8 +5,8 @@ import { applyThemeTokens } from "../src/ui/tokens/inject.js";
 import { resolveStoryTokens } from "./story-token-map.js";
 import type { LvisThemePayload } from "../src/ui/tokens/index.js";
 
-const VALID_THEMES = new Set(["light", "dark", "high-contrast"] as const);
-const VALID_CHAT_THEMES = new Set(["default", "lg", "purple", "orange", "blue"] as const);
+const VALID_THEMES = new Set<string>(["light", "dark", "high-contrast"]);
+const VALID_CHAT_THEMES = new Set<string>(["default", "lg", "purple", "orange", "blue"]);
 
 const preview: Preview = {
   decorators: [

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,16 +3,25 @@ import type { Preview } from "@storybook/react";
 import "../src/ui/tokens/lvis-tokens.css";
 import { applyThemeTokens } from "../src/ui/tokens/inject.js";
 import { resolveStoryTokens } from "./story-token-map.js";
+import type { LvisThemePayload } from "../src/ui/tokens/index.js";
+
+const VALID_THEMES = new Set(["light", "dark", "high-contrast"] as const);
+const VALID_CHAT_THEMES = new Set(["default", "lg", "purple", "orange", "blue"] as const);
 
 const preview: Preview = {
   decorators: [
     (Story, ctx) => {
-      const theme = (ctx.globals.theme as string) ?? "dark";
-      const chatTheme = (ctx.globals.chatTheme as string) ?? "purple";
+      const rawTheme = (ctx.globals.theme as string) ?? "dark";
+      const rawChatTheme = (ctx.globals.chatTheme as string) ?? "purple";
+      // Validate globals before passing — toolbar values are strings at runtime.
+      const theme: LvisThemePayload["theme"] = VALID_THEMES.has(rawTheme as LvisThemePayload["theme"])
+        ? (rawTheme as LvisThemePayload["theme"]) : "dark";
+      const chatTheme: LvisThemePayload["chatTheme"] = VALID_CHAT_THEMES.has(rawChatTheme as LvisThemePayload["chatTheme"])
+        ? (rawChatTheme as LvisThemePayload["chatTheme"]) : "default";
       useEffect(() => {
         // Apply computed token values directly — no longer relies on
         // data-theme/data-chat-theme CSS selectors in lvis-tokens.css.
-        applyThemeTokens(resolveStoryTokens(theme as "light" | "dark" | "high-contrast", chatTheme as "default" | "lg" | "purple" | "orange" | "blue"));
+        applyThemeTokens(resolveStoryTokens(theme, chatTheme));
         // Set data-* attributes for debugging / devtools inspection.
         document.documentElement.setAttribute("data-theme", theme);
         if (chatTheme === "default") {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,10 +12,14 @@ const preview: Preview = {
       useEffect(() => {
         // Apply computed token values directly — no longer relies on
         // data-theme/data-chat-theme CSS selectors in lvis-tokens.css.
-        applyThemeTokens(resolveStoryTokens(theme, chatTheme));
-        // Still set data-theme for debugging / future CSS use.
+        applyThemeTokens(resolveStoryTokens(theme as "light" | "dark" | "high-contrast", chatTheme as "default" | "lg" | "purple" | "orange" | "blue"));
+        // Set data-* attributes for debugging / devtools inspection.
         document.documentElement.setAttribute("data-theme", theme);
-        document.documentElement.removeAttribute("data-chat-theme");
+        if (chatTheme === "default") {
+          document.documentElement.removeAttribute("data-chat-theme");
+        } else {
+          document.documentElement.setAttribute("data-chat-theme", chatTheme);
+        }
       }, [theme, chatTheme]);
       return (
         <div style={{ padding: "1.5rem", background: "var(--lvis-bg)", minHeight: "100vh" }}>

--- a/.storybook/story-token-map.ts
+++ b/.storybook/story-token-map.ts
@@ -5,6 +5,7 @@
 //
 // Keep in sync with: lvis-app/src/ui/renderer/theme/plugin-token-map.ts
 // and: lvis-app/src/styles.css
+import type { LvisThemePayload } from "../src/ui/tokens/index.js";
 
 const _H = (h: number, s: number, l: number) => `hsl(${h}, ${s}%, ${l}%)`;
 
@@ -95,12 +96,14 @@ const _LG_DARK_SURFACE: Record<string, string> = {
 };
 
 export function resolveStoryTokens(
-  theme: string,
-  chatTheme: string,
+  theme: LvisThemePayload["theme"],
+  chatTheme: LvisThemePayload["chatTheme"],
 ): Record<string, string> {
   const base = theme === "light" ? _LIGHT_BASE : theme === "high-contrast" ? _HC_BASE : _DARK_BASE;
   if (theme === "high-contrast") return { ...base };
   switch (chatTheme) {
+    case "default":
+      return { ...base };
     case "lg": {
       const surface = theme === "dark" ? _LG_DARK_SURFACE : _LG_LIGHT_SURFACE;
       return { ...base, ...surface, ..._LG_ACCENT };
@@ -115,7 +118,5 @@ export function resolveStoryTokens(
       return theme === "dark"
         ? { ...base, "--lvis-primary": _H(217.2, 91.2, 59.8), "--lvis-ring": _H(224.3, 76.3, 48) }
         : { ...base, "--lvis-primary": _H(224.3, 76.3, 48), "--lvis-ring": _H(217.2, 91.2, 59.8) };
-    default:
-      return { ...base };
   }
 }

--- a/.storybook/story-token-map.ts
+++ b/.storybook/story-token-map.ts
@@ -118,5 +118,7 @@ export function resolveStoryTokens(
       return theme === "dark"
         ? { ...base, "--lvis-primary": _H(217.2, 91.2, 59.8), "--lvis-ring": _H(224.3, 76.3, 48) }
         : { ...base, "--lvis-primary": _H(224.3, 76.3, 48), "--lvis-ring": _H(217.2, 91.2, 59.8) };
+    default:
+      return { ...base };
   }
 }

--- a/.storybook/story-token-map.ts
+++ b/.storybook/story-token-map.ts
@@ -1,0 +1,121 @@
+// Storybook-only token resolver. Mirrors lvis-app's plugin-token-map.ts so
+// Storybook can apply the correct --lvis-* values when toolbar theme changes,
+// without relying on CSS data-theme selectors (which were removed from
+// lvis-tokens.css once computed-token IPC transmission landed).
+//
+// Keep in sync with: lvis-app/src/ui/renderer/theme/plugin-token-map.ts
+// and: lvis-app/src/styles.css
+
+const _H = (h: number, s: number, l: number) => `hsl(${h}, ${s}%, ${l}%)`;
+
+const _DARK_BASE: Record<string, string> = {
+  "--lvis-bg":           _H(222.2, 84,   4.9),
+  "--lvis-surface":      _H(222.2, 84,   7  ),
+  "--lvis-fg":           _H(210,   40,  98  ),
+  "--lvis-fg-muted":     _H(215,   20,  65  ),
+  "--lvis-primary":      _H(217.2, 91.2,59.8),
+  "--lvis-primary-fg":   _H(210,   40,  98  ),
+  "--lvis-secondary":    _H(217,   33,  17  ),
+  "--lvis-secondary-fg": _H(210,   40,  98  ),
+  "--lvis-danger":       _H(0,     62.8,30.6),
+  "--lvis-danger-fg":    _H(210,   40,  98  ),
+  "--lvis-warning":      _H(48,    97,  77  ),
+  "--lvis-warning-fg":   _H(30,    80,  25  ),
+  "--lvis-success":      _H(142,   71,  45  ),
+  "--lvis-border":       _H(217,   33,  17  ),
+  "--lvis-ring":         _H(224.3, 76.3,48  ),
+  "--lvis-radius":       "0.6rem",
+  "--lvis-radius-sm":    "0.25rem",
+};
+
+const _LIGHT_BASE: Record<string, string> = {
+  "--lvis-bg":           _H(0,     0,  100  ),
+  "--lvis-surface":      _H(0,     0,  100  ),
+  "--lvis-fg":           _H(222,   47,  11  ),
+  "--lvis-fg-muted":     _H(215,   16,  47  ),
+  "--lvis-primary":      _H(224.3, 76.3,48  ),
+  "--lvis-primary-fg":   _H(210,   40,  98  ),
+  "--lvis-secondary":    _H(210,   40,  96  ),
+  "--lvis-secondary-fg": _H(222,   47,  11  ),
+  "--lvis-danger":       _H(0,     84,  60  ),
+  "--lvis-danger-fg":    _H(210,   40,  98  ),
+  "--lvis-warning":      _H(48,    96,  89  ),
+  "--lvis-warning-fg":   _H(30,    80,  25  ),
+  "--lvis-success":      _H(142,   71,  45  ),
+  "--lvis-border":       _H(214,   32,  91  ),
+  "--lvis-ring":         _H(217.2, 91.2,59.8),
+  "--lvis-radius":       "0.6rem",
+  "--lvis-radius-sm":    "0.25rem",
+};
+
+const _HC_BASE: Record<string, string> = {
+  "--lvis-bg":           _H(0,   0,   0  ),
+  "--lvis-surface":      _H(0,   0,   0  ),
+  "--lvis-fg":           _H(0,   0, 100  ),
+  "--lvis-fg-muted":     _H(0,   0,  80  ),
+  "--lvis-primary":      _H(60, 100,  50  ),
+  "--lvis-primary-fg":   _H(0,   0,   0  ),
+  "--lvis-secondary":    _H(0,   0,  15  ),
+  "--lvis-secondary-fg": _H(0,   0, 100  ),
+  "--lvis-danger":       _H(0, 100,  50  ),
+  "--lvis-danger-fg":    _H(0,   0, 100  ),
+  "--lvis-warning":      _H(48, 100,  50  ),
+  "--lvis-warning-fg":   _H(0,   0,   0  ),
+  "--lvis-success":      _H(120, 100,  40  ),
+  "--lvis-border":       _H(0,   0, 100  ),
+  "--lvis-ring":         _H(60, 100,  50  ),
+  "--lvis-radius":       "0.6rem",
+  "--lvis-radius-sm":    "0.25rem",
+};
+
+const _LG_ACCENT: Record<string, string> = {
+  "--lvis-primary":     _H(253, 100, 65),
+  "--lvis-primary-fg":  _H(0,     0, 100),
+  "--lvis-ring":        _H(263,  70,  50),
+  "--lvis-danger":      _H(1,    98,  59),
+  "--lvis-danger-fg":   _H(0,     0, 100),
+};
+const _LG_LIGHT_SURFACE: Record<string, string> = {
+  "--lvis-bg":           _H(40,  25,  92),
+  "--lvis-surface":      _H(44,  37,  94),
+  "--lvis-fg":           _H(0,    0,  15),
+  "--lvis-fg-muted":     _H(43,   3,  43),
+  "--lvis-secondary":    _H(44,  37,  94),
+  "--lvis-secondary-fg": _H(0,    0,  15),
+  "--lvis-border":       _H(40,  10,  78),
+};
+const _LG_DARK_SURFACE: Record<string, string> = {
+  "--lvis-bg":           _H(0,    0,  15),
+  "--lvis-surface":      _H(0,    0,  18),
+  "--lvis-fg":           _H(44,  37,  94),
+  "--lvis-fg-muted":     _H(40,   5,  60),
+  "--lvis-secondary":    _H(0,    0,  20),
+  "--lvis-secondary-fg": _H(44,  37,  94),
+  "--lvis-border":       _H(0,    0,  28),
+};
+
+export function resolveStoryTokens(
+  theme: string,
+  chatTheme: string,
+): Record<string, string> {
+  const base = theme === "light" ? _LIGHT_BASE : theme === "high-contrast" ? _HC_BASE : _DARK_BASE;
+  if (theme === "high-contrast") return { ...base };
+  switch (chatTheme) {
+    case "lg": {
+      const surface = theme === "dark" ? _LG_DARK_SURFACE : _LG_LIGHT_SURFACE;
+      return { ...base, ...surface, ..._LG_ACCENT };
+    }
+    case "purple":
+      return { ...base, "--lvis-primary": _H(262, 83, 58), "--lvis-primary-fg": _H(0, 0, 100), "--lvis-ring": _H(263, 70, 50) };
+    case "orange":
+      return theme === "dark"
+        ? { ...base, "--lvis-primary": _H(25, 95, 53), "--lvis-primary-fg": _H(0, 0, 100), "--lvis-ring": _H(21, 90, 48) }
+        : { ...base, "--lvis-primary": _H(21, 90, 48), "--lvis-primary-fg": _H(0, 0, 100), "--lvis-ring": _H(25, 95, 53) };
+    case "blue":
+      return theme === "dark"
+        ? { ...base, "--lvis-primary": _H(217.2, 91.2, 59.8), "--lvis-ring": _H(224.3, 76.3, 48) }
+        : { ...base, "--lvis-primary": _H(224.3, 76.3, 48), "--lvis-ring": _H(217.2, 91.2, 59.8) };
+    default:
+      return { ...base };
+  }
+}

--- a/src/ui/__tests__/useTheme.test.ts
+++ b/src/ui/__tests__/useTheme.test.ts
@@ -70,6 +70,17 @@ describe("useTheme", () => {
     expect(document.documentElement.style.getPropertyValue("--evil-key")).toBe("");
   });
 
+  it("drops --lvis-* key not in LVIS_TOKEN_NAMES closed set", () => {
+    const bridge = makeBridge();
+    renderHook(() => useTheme(bridge));
+    bridge.fire({
+      theme: "dark", chatTheme: "default", codeTheme: "dark",
+      tokens: { "--lvis-bg": "#000", "--lvis-nonexistent-custom": "red" },
+    });
+    expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("#000");
+    expect(document.documentElement.style.getPropertyValue("--lvis-nonexistent-custom")).toBe("");
+  });
+
   it("rejects invalid theme enum — does not set data-theme", () => {
     const bridge = makeBridge();
     renderHook(() => useTheme(bridge));

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
-import type { LvisThemePayload } from "../tokens/index.js";
+import { type LvisThemePayload, LVIS_TOKEN_NAMES } from "../tokens/index.js";
 import { applyThemeTokens } from "../tokens/inject.js";
-import { LVIS_TOKEN_NAMES } from "../tokens/index.js";
 
 type PluginBridge = {
   onEvent: (type: string, handler: (data: unknown) => void) => () => void;

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { LvisThemePayload } from "../tokens/index.js";
 import { applyThemeTokens } from "../tokens/inject.js";
+import { LVIS_TOKEN_NAMES } from "../tokens/index.js";
 
 type PluginBridge = {
   onEvent: (type: string, handler: (data: unknown) => void) => () => void;
@@ -9,11 +10,21 @@ type PluginBridge = {
 const VALID_THEMES = new Set<string>(["light", "dark", "high-contrast"]);
 const VALID_CHAT_THEMES = new Set<string>(["lg", "purple", "orange", "blue"]);
 const VALID_CODE_THEMES = new Set<string>(["light", "dark"]);
+// Closed allowlist mirrors LVIS_TOKEN_NAMES — same set as inject.ts:_ALLOWED_KEYS.
+const _ALLOWED_TOKEN_KEYS = new Set<string>(LVIS_TOKEN_NAMES);
 
 /**
- * Subscribe to host theme changes. Sets data-theme / data-chat-theme /
- * data-code-theme on <html> so lvis-tokens.css selectors activate, then
- * applies any explicit --lvis-* token overrides when provided.
+ * Subscribe to host theme changes via the plugin bridge.
+ *
+ * When `host.theme.changed` fires with a `tokens` field, applies computed
+ * `--lvis-*` values directly via style.setProperty (inline style wins over
+ * any stylesheet). The `data-theme`/`data-chat-theme`/`data-code-theme`
+ * attributes are set for devtools inspection only — there are no CSS selector
+ * blocks in lvis-tokens.css that react to them.
+ *
+ * When `tokens` is absent the plugin retains its current token state;
+ * initial render uses the :root fallback values in lvis-tokens.css (dark).
+ *
  * Call once at the plugin's root component.
  */
 export function useTheme(bridge: PluginBridge): void {
@@ -36,7 +47,7 @@ export function useTheme(bridge: PluginBridge): void {
       if (payload.tokens) {
         const safe: Record<string, string> = {};
         for (const [k, v] of Object.entries(payload.tokens)) {
-          if (k.startsWith("--lvis-") && typeof v === "string") safe[k] = v;
+          if (_ALLOWED_TOKEN_KEYS.has(k) && typeof v === "string") safe[k] = v;
         }
         if (Object.keys(safe).length > 0) applyThemeTokens(safe);
       }

--- a/src/ui/tokens/index.ts
+++ b/src/ui/tokens/index.ts
@@ -15,6 +15,6 @@ export type LvisThemePayload = {
   theme: "light" | "dark" | "high-contrast";
   chatTheme: "default" | "lg" | "purple" | "orange" | "blue";
   codeTheme: "light" | "dark";
-  /** Optional explicit token values. When absent, CSS data-theme selectors handle theming. */
+  /** Optional explicit token values. When absent, :root fallback values in lvis-tokens.css apply until host broadcasts via host.theme.changed. */
   tokens?: Partial<LvisThemeTokens>;
 };

--- a/src/ui/tokens/lvis-tokens.css
+++ b/src/ui/tokens/lvis-tokens.css
@@ -12,7 +12,10 @@
 
 /* ─── Dark (default fallback) ────────────────────────────
  * Values mirror lvis-app src/ui/renderer/theme/plugin-token-map.ts _DARK_BASE.
- * Update both files when the design palette changes.
+ * Three files must stay in sync when the design palette changes:
+ *   1. lvis-app/src/ui/renderer/theme/plugin-token-map.ts  (_DARK_BASE)
+ *   2. lvis-plugin-sdk/src/ui/tokens/lvis-tokens.css       (:root below)
+ *   3. lvis-plugin-sdk/.storybook/story-token-map.ts       (_DARK_BASE)
  * ────────────────────────────────────────────────────── */
 :root {
   --lvis-bg:           hsl(222.2, 84%, 4.9%);

--- a/src/ui/tokens/lvis-tokens.css
+++ b/src/ui/tokens/lvis-tokens.css
@@ -1,105 +1,35 @@
 /* @lvis/plugin-sdk — Plugin UI Tokens
- * Default = dark. Host broadcasts theme axis via host.theme.changed;
- * useTheme() sets data-theme / data-chat-theme on documentElement so these
- * selectors activate automatically — no JS token-swap needed.
+ *
+ * These :root defaults serve as an initial fallback until the host broadcasts
+ * computed values via host.theme.changed → useTheme() → applyThemeTokens().
+ * Once tokens arrive, inline style.setProperty() overwrites these values.
+ *
+ * Do NOT add data-theme / data-chat-theme variant blocks here — those are
+ * now redundant and diverge from lvis-app/src/styles.css.
+ * The host (lvis-app) is the single source of truth for token values.
+ * See: src/ui/tokens/inject.ts:applyThemeTokens, src/ui/hooks/useTheme.ts
  */
 
-/* ─── Dark (default) ─────────────────────────────────── */
+/* ─── Dark (default fallback) ────────────────────────────
+ * Values mirror lvis-app src/ui/renderer/theme/plugin-token-map.ts _DARK_BASE.
+ * Update both files when the design palette changes.
+ * ────────────────────────────────────────────────────── */
 :root {
-  --lvis-bg:           #0f0f13;
-  --lvis-surface:      #1a1a22;
-  --lvis-fg:           #f5f5f5;
-  --lvis-fg-muted:     #888888;
-  --lvis-primary:      #a078f5;
-  --lvis-primary-fg:   #ffffff;
-  --lvis-secondary:    #2d2d38;
-  --lvis-secondary-fg: #f5f5f5;
-  --lvis-danger:       #f03e2f;
-  --lvis-danger-fg:    #ffffff;
-  --lvis-warning:      #f5a050;
-  --lvis-warning-fg:   #1a1a1a;
-  --lvis-success:      #22c55e;
-  --lvis-border:       #2d2d38;
-  --lvis-ring:         #a078f5;
+  --lvis-bg:           hsl(222.2, 84%, 4.9%);
+  --lvis-surface:      hsl(222.2, 84%, 7%);
+  --lvis-fg:           hsl(210, 40%, 98%);
+  --lvis-fg-muted:     hsl(215, 20%, 65%);
+  --lvis-primary:      hsl(217.2, 91.2%, 59.8%);
+  --lvis-primary-fg:   hsl(210, 40%, 98%);
+  --lvis-secondary:    hsl(217, 33%, 17%);
+  --lvis-secondary-fg: hsl(210, 40%, 98%);
+  --lvis-danger:       hsl(0, 62.8%, 30.6%);
+  --lvis-danger-fg:    hsl(210, 40%, 98%);
+  --lvis-warning:      hsl(48, 97%, 77%);
+  --lvis-warning-fg:   hsl(30, 80%, 25%);
+  --lvis-success:      hsl(142, 71%, 45%);
+  --lvis-border:       hsl(217, 33%, 17%);
+  --lvis-ring:         hsl(224.3, 76.3%, 48%);
   --lvis-radius:       0.6rem;
-  --lvis-radius-sm:    0.2rem;
-}
-
-/* ─── Light ──────────────────────────────────────────── */
-:root[data-theme="light"] {
-  --lvis-bg:           #f8f8fc;
-  --lvis-surface:      #ffffff;
-  --lvis-fg:           #1a1a22;
-  --lvis-fg-muted:     #666677;
-  --lvis-primary:      #734dff;
-  --lvis-primary-fg:   #ffffff;
-  --lvis-secondary:    #ebebf5;
-  --lvis-secondary-fg: #1a1a22;
-  --lvis-danger:       #e02020;
-  --lvis-danger-fg:    #ffffff;
-  --lvis-warning:      #d97706;
-  --lvis-warning-fg:   #ffffff;
-  --lvis-success:      #16a34a;
-  --lvis-border:       #d4d4e0;
-  --lvis-ring:         #734dff;
-}
-
-/* ─── High-contrast ──────────────────────────────────── */
-:root[data-theme="high-contrast"] {
-  --lvis-bg:           #000000;
-  --lvis-surface:      #0a0a0a;
-  --lvis-fg:           #ffffff;
-  --lvis-fg-muted:     #cccccc;
-  --lvis-primary:      #c497ef;
-  --lvis-primary-fg:   #000000;
-  --lvis-secondary:    #1a1a1a;
-  --lvis-secondary-fg: #ffffff;
-  --lvis-danger:       #ff4444;
-  --lvis-danger-fg:    #000000;
-  --lvis-warning:      #ffaa00;
-  --lvis-warning-fg:   #000000;
-  --lvis-success:      #00ff88;
-  --lvis-border:       #ffffff;
-  --lvis-ring:         #c497ef;
-}
-
-/* ─── Chat theme accent overrides ────────────────────── */
-:root[data-chat-theme="purple"] {
-  --lvis-primary:    #a078f5;
-  --lvis-ring:       #a078f5;
-}
-:root[data-chat-theme="orange"] {
-  --lvis-primary:    #f5a050;
-  --lvis-primary-fg: #1a1a1a;
-  --lvis-ring:       #f5a050;
-}
-:root[data-chat-theme="blue"] {
-  --lvis-primary:    #60a5fa;
-  --lvis-ring:       #60a5fa;
-}
-/* LG brand — light variant (warm-grey surface, lilac bubble, vivid purple SEND)
-   Mirrors lvis-app/src/styles.css [data-chat-theme="lg"] */
-:root[data-chat-theme="lg"] {
-  --lvis-primary:      #734dff;   /* vivid purple — SEND button */
-  --lvis-primary-fg:   #ffffff;
-  --lvis-ring:         #734dff;
-  --lvis-bg:           #f0ece4;   /* Grey 6 — warm-grey chat surface */
-  --lvis-surface:      #f6f3eb;   /* Grey 7 — slight elevation */
-  --lvis-fg:           #262626;   /* Grey 1 */
-  --lvis-fg-muted:     #716f6a;   /* Grey 3 */
-  --lvis-secondary:    #f6f3eb;
-  --lvis-secondary-fg: #262626;
-  --lvis-border:       #cbc8c2;   /* Grey 4 */
-  --lvis-danger:       #fd312e;   /* LG red */
-  --lvis-danger-fg:    #ffffff;
-}
-/* LG brand — dark variant (warm-neutral inversion, accent inherited) */
-:root[data-theme="dark"][data-chat-theme="lg"] {
-  --lvis-bg:           #262626;   /* Grey 1 */
-  --lvis-surface:      #2e2e2e;
-  --lvis-fg:           #f6f3eb;   /* Grey 7 */
-  --lvis-fg-muted:     #9e9c99;
-  --lvis-secondary:    #333333;
-  --lvis-secondary-fg: #f6f3eb;
-  --lvis-border:       #474747;
+  --lvis-radius-sm:    0.25rem;
 }


### PR DESCRIPTION
## 요약

lvis-app PR #512(computed token 전송) 착지 이후 후속 정리 작업.

- `lvis-tokens.css`의 `data-theme` / `data-chat-theme` CSS 셀렉터 블록 제거
- `:root` 기본값만 유지 (dark fallback — `host.theme.changed` 수신 전 초기 렌더링용)
- 기본값을 lvis-app `plugin-token-map.ts _DARK_BASE`와 동기화 (이전 값 drift 해소)
- `.storybook/story-token-map.ts` 추가 — `resolveStoryTokens()`: CSS 셀렉터 없이 Storybook이 JS로 직접 토큰 적용
- `preview.tsx`: `applyThemeTokens(resolveStoryTokens(theme, chatTheme))` 방식으로 전환

## 배경

기존 `lvis-tokens.css`의 variant 블록은 lvis-app `styles.css`와 이중 관리 문제가 있었고, PR #512 이후 `applyThemeTokens()` inline style이 CSS 셀렉터를 덮어쓰므로 dead weight가 됨. 단일 source of truth는 lvis-app.

## 테스트 계획

- [x] `bun run test` — 149 tests pass
- [ ] Storybook 실행 후 툴바 테마/악센트 전환 시 색상 반영 확인

## 관련

- Closes #83
- Depends on lvis-app #512 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)