### PR TITLE
refactor(ui): injectTokenCss render body → 모듈 스코프로 이동

### DIFF
--- a/src/ui/components/Badge.tsx
+++ b/src/ui/components/Badge.tsx
@@ -12,6 +12,7 @@ const CSS = `
 .lvis-badge-warning { background: var(--lvis-warning); color: var(--lvis-warning-fg); }
 .lvis-badge-danger  { background: var(--lvis-danger);  color: var(--lvis-danger-fg); }
 `;
+injectTokenCss("lvis-badge", CSS);
 
 export type BadgeVariant = "default" | "success" | "warning" | "danger";
 
@@ -20,7 +21,6 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 export function Badge({ variant = "default", className = "", children, ...rest }: BadgeProps) {
-  injectTokenCss("lvis-badge", CSS);
   const cls = ["lvis-badge", `lvis-badge-${variant}`, className].filter(Boolean).join(" ");
   return <span {...rest} className={cls}>{children}</span>;
 }

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -31,6 +31,7 @@ const CSS = `
 .lvis-btn-sm { padding: 0.25rem 0.625rem; font-size: 0.75rem; }
 .lvis-btn-lg { padding: 0.5rem 1.125rem; font-size: 1rem; }
 `;
+injectTokenCss("lvis-btn", CSS);
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 export type ButtonSize = "sm" | "md" | "lg";
@@ -44,7 +45,6 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 export function Button({
   variant = "primary", size = "md", loading, children, className = "", disabled, ...rest
 }: ButtonProps) {
-  injectTokenCss("lvis-btn", CSS);
   const cls = [
     "lvis-btn",
     `lvis-btn-${variant}`,

--- a/src/ui/components/Card.tsx
+++ b/src/ui/components/Card.tsx
@@ -9,13 +9,13 @@ const CSS = `
 .lvis-card-sm { padding: 0.625rem; }
 .lvis-card-lg { padding: 1.5rem; }
 `;
+injectTokenCss("lvis-card", CSS);
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   padding?: "sm" | "md" | "lg";
 }
 
 export function Card({ padding = "md", className = "", children, ...rest }: CardProps) {
-  injectTokenCss("lvis-card", CSS);
   const cls = ["lvis-card", padding !== "md" ? `lvis-card-${padding}` : "", className]
     .filter(Boolean).join(" ");
   return <div {...rest} className={cls}>{children}</div>;

--- a/src/ui/components/Checkbox.tsx
+++ b/src/ui/components/Checkbox.tsx
@@ -41,6 +41,7 @@ const CSS = `
 .lvis-checkbox-disabled { opacity: 0.5; cursor: not-allowed; }
 .lvis-checkbox-label { font-size: 0.875rem; color: var(--lvis-fg); }
 `;
+injectTokenCss("lvis-checkbox", CSS);
 
 export interface CheckboxProps {
   checked?: boolean;
@@ -53,7 +54,6 @@ export interface CheckboxProps {
 }
 
 export function Checkbox({ checked, defaultChecked, indeterminate, onChange, label, disabled, id }: CheckboxProps) {
-  injectTokenCss("lvis-checkbox", CSS);
   const [internal, setInternal] = React.useState(defaultChecked ?? false);
   const isOn = checked !== undefined ? checked : internal;
 

--- a/src/ui/components/Input.tsx
+++ b/src/ui/components/Input.tsx
@@ -16,13 +16,13 @@ const CSS = `
 .lvis-input-error { border-color: var(--lvis-danger); }
 .lvis-input-error:focus { border-color: var(--lvis-danger); box-shadow: 0 0 0 2px color-mix(in srgb, var(--lvis-danger) 25%, transparent); }
 `;
+injectTokenCss("lvis-input", CSS);
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
 }
 
 export function Input({ error, className = "", ...rest }: InputProps) {
-  injectTokenCss("lvis-input", CSS);
   const cls = ["lvis-input", error ? "lvis-input-error" : "", className].filter(Boolean).join(" ");
   return <input {...rest} className={cls} />;
 }

--- a/src/ui/components/Select.tsx
+++ b/src/ui/components/Select.tsx
@@ -17,11 +17,11 @@ const CSS = `
 .lvis-select:focus { border-color: var(--lvis-ring); box-shadow: 0 0 0 2px color-mix(in srgb, var(--lvis-ring) 25%, transparent); }
 .lvis-select:disabled { opacity: 0.5; cursor: not-allowed; }
 `;
+injectTokenCss("lvis-select", CSS);
 
 export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
 
 export function Select({ className = "", children, ...rest }: SelectProps) {
-  injectTokenCss("lvis-select", CSS);
   const cls = ["lvis-select", className].filter(Boolean).join(" ");
   return <select {...rest} className={cls}>{children}</select>;
 }

--- a/src/ui/components/Text.tsx
+++ b/src/ui/components/Text.tsx
@@ -8,6 +8,7 @@ const CSS = `
 .lvis-text-label  { font-size: 0.75rem;  color: var(--lvis-fg-muted); font-weight: 500; line-height: 1.4; text-transform: uppercase; letter-spacing: 0.05em; }
 .lvis-text-heading{ font-size: 1rem;     color: var(--lvis-fg); font-weight: 600; line-height: 1.4; }
 `;
+injectTokenCss("lvis-text", CSS);
 
 export type TextVariant = "body" | "muted" | "label" | "heading";
 
@@ -17,7 +18,6 @@ export interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
 }
 
 export function Text({ variant = "body", as: Tag = "p", className = "", children, ...rest }: TextProps) {
-  injectTokenCss("lvis-text", CSS);
   const cls = ["lvis-text", `lvis-text-${variant}`, className].filter(Boolean).join(" ");
   return <Tag {...rest} className={cls}>{children}</Tag>;
 }

--- a/src/ui/components/Toggle.tsx
+++ b/src/ui/components/Toggle.tsx
@@ -24,6 +24,7 @@ const CSS = `
 .lvis-toggle-disabled { opacity: 0.5; cursor: not-allowed; }
 .lvis-toggle-label { font-size: 0.875rem; color: var(--lvis-fg); }
 `;
+injectTokenCss("lvis-toggle", CSS);
 
 export interface ToggleProps {
   checked?: boolean;
@@ -35,7 +36,6 @@ export interface ToggleProps {
 }
 
 export function Toggle({ checked, defaultChecked, onChange, label, disabled, id }: ToggleProps) {
-  injectTokenCss("lvis-toggle", CSS);
   const [internal, setInternal] = React.useState(defaultChecked ?? false);
   const isOn = checked !== undefined ? checked : internal;
 


### PR DESCRIPTION
## 요약

8개 컴포넌트(Badge, Button, Card, Checkbox, Input, Select, Text, Toggle)에서 render body 안의 `injectTokenCss(...)` 호출을 모듈 스코프(CSS const 바로 다음)로 이동.

## 배경

render body 안에서 호출하면 매 render마다 `getElementById` DOM 쿼리가 발생. `injectTokenCss` 자체에 중복 삽입 방지 로직이 있어 기능 문제는 없었으나 불필요한 DOM 접근이 매번 실행됨.

`injectTokenCss`에 이미 `typeof document === "undefined" return` SSR guard가 있어 모듈 스코프 호출도 안전.

## 변경 내용

```ts
// Before
export function Badge(...) {
  injectTokenCss("lvis-badge", CSS);  // render마다 실행
  ...
}

// After
injectTokenCss("lvis-badge", CSS);  // 모듈 로드 시 1회

export function Badge(...) {
  ...
}
```

## 테스트

- [x] `bun run test` — 150 tests pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)