### PR TITLE
feat(runtime): add electron helper — getSafeStorage / getShell + test seams (closes #89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lvis/plugin-sdk",
   "version": "3.5.0",
   "private": false,
-  "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
+  "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",
   "types": "./src/index.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "private": false,
   "description": "Type-only SDK for authoring LVIS plugins. Re-exports the host's PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin contracts so plugin repos can import a single source of truth.",
   "type": "module",
@@ -22,6 +22,10 @@
     "./build": {
       "types": "./src/build/tsup.ts",
       "import": "./dist/build/tsup.js"
+    },
+    "./runtime/electron": {
+      "types": "./src/runtime/electron.ts",
+      "import": "./dist/runtime/electron.js"
     },
     "./schemas/plugin-manifest.schema.json": "./schemas/plugin-manifest.schema.json",
     "./schemas/*": "./schemas/*"

--- a/src/__tests__/runtime-electron.test.ts
+++ b/src/__tests__/runtime-electron.test.ts
@@ -87,3 +87,76 @@ describe("runtime/electron — seam isolation", () => {
     expect(getShell()).toBeNull();
   });
 });
+
+describe("runtime/electron — production guard", () => {
+  // The seam exports are reachable from any plugin via
+  // `@lvis/plugin-sdk/runtime/electron`. Without a runtime guard, a
+  // buggy or compromised plugin could call them in a packaged build
+  // and hijack every other plugin's token storage. The guard throws
+  // when NODE_ENV=production and neither VITEST nor LVIS_TEST is set.
+
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env for subsequent tests.
+    for (const key of ["NODE_ENV", "VITEST", "LVIS_TEST"]) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    __setSafeStorageForTests(undefined);
+    __setShellForTests(undefined);
+  });
+
+  it("throws when called with NODE_ENV=production and no test signal", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.VITEST;
+    delete process.env.LVIS_TEST;
+    expect(() => __setSafeStorageForTests(null)).toThrow(/test seam called in production/);
+    expect(() => __setShellForTests(null)).toThrow(/test seam called in production/);
+  });
+
+  it("allows the call when LVIS_TEST=1 even in production builds", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.VITEST;
+    process.env.LVIS_TEST = "1";
+    expect(() => __setSafeStorageForTests(null)).not.toThrow();
+    expect(() => __setShellForTests(null)).not.toThrow();
+  });
+
+  it("allows the call when VITEST=true (set by vitest itself)", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VITEST = "true";
+    expect(() => __setSafeStorageForTests(null)).not.toThrow();
+  });
+});
+
+describe("runtime/electron — diagnostic completeness", () => {
+  // Coverage gap previously: the `try/catch → null` branches on
+  // getSafeStorage / getShell had no explicit test. Without these,
+  // a future refactor that removes the catch and re-throws would
+  // ship green.
+  afterEach(() => {
+    __setSafeStorageForTests(undefined);
+    __setShellForTests(undefined);
+  });
+
+  it("getSafeStorage does not throw even without electron available — null fallback", () => {
+    expect(() => getSafeStorage()).not.toThrow();
+    expect(getSafeStorage()).toBeNull();
+  });
+
+  it("getShell does not throw even without electron available — null fallback", () => {
+    expect(() => getShell()).not.toThrow();
+    expect(getShell()).toBeNull();
+  });
+
+  it("seam reset to undefined falls back to real lookup (not stale value)", () => {
+    const stale = { openExternal: async () => undefined };
+    __setShellForTests(stale);
+    expect(getShell()).toBe(stale);
+    __setShellForTests(undefined);
+    // After reset, real lookup runs — returns null in this Node-only test process.
+    expect(getShell()).toBeNull();
+    expect(getShell()).not.toBe(stale);
+  });
+});

--- a/src/__tests__/runtime-electron.test.ts
+++ b/src/__tests__/runtime-electron.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getSafeStorage,
+  getShell,
+  __setSafeStorageForTests,
+  __setShellForTests,
+} from "../runtime/electron.js";
+
+describe("runtime/electron — safeStorage seam", () => {
+  afterEach(() => {
+    __setSafeStorageForTests(undefined);
+  });
+
+  it("returns null by default outside Electron (no seam)", () => {
+    expect(getSafeStorage()).toBeNull();
+  });
+
+  it("returns the override when set", () => {
+    const mock = {
+      isEncryptionAvailable: () => true,
+      encryptString: (s: string) => Buffer.from(s),
+      decryptString: (b: Buffer) => b.toString(),
+    };
+    __setSafeStorageForTests(mock);
+    expect(getSafeStorage()).toBe(mock);
+  });
+
+  it("returns null when override is explicitly null (force-unavailable)", () => {
+    __setSafeStorageForTests(null);
+    expect(getSafeStorage()).toBeNull();
+  });
+
+  it("falls back to real lookup when override is undefined", () => {
+    __setSafeStorageForTests({
+      isEncryptionAvailable: () => true,
+      encryptString: () => Buffer.alloc(0),
+      decryptString: () => "",
+    });
+    __setSafeStorageForTests(undefined);
+    expect(getSafeStorage()).toBeNull();
+  });
+});
+
+describe("runtime/electron — shell seam", () => {
+  afterEach(() => {
+    __setShellForTests(undefined);
+  });
+
+  it("returns null by default outside Electron (no seam)", () => {
+    expect(getShell()).toBeNull();
+  });
+
+  it("returns the override when set", () => {
+    const mock = { openExternal: async () => undefined };
+    __setShellForTests(mock);
+    expect(getShell()).toBe(mock);
+  });
+
+  it("returns null when override is explicitly null", () => {
+    __setShellForTests(null);
+    expect(getShell()).toBeNull();
+  });
+
+  it("does not throw when underlying require fails — returns null", () => {
+    // No seam set; createRequire("electron") in this Node-only test
+    // process resolves to the npm electron path-string export which has
+    // no `.shell` property → wrapped lookup returns null without throw.
+    expect(() => getShell()).not.toThrow();
+  });
+});
+
+describe("runtime/electron — seam isolation", () => {
+  afterEach(() => {
+    __setSafeStorageForTests(undefined);
+    __setShellForTests(undefined);
+  });
+
+  it("safeStorage seam does not affect shell seam", () => {
+    const safeStorage = {
+      isEncryptionAvailable: () => true,
+      encryptString: () => Buffer.alloc(0),
+      decryptString: () => "",
+    };
+    __setSafeStorageForTests(safeStorage);
+    expect(getSafeStorage()).toBe(safeStorage);
+    // shell still uses the real (null) lookup since no seam was set
+    expect(getShell()).toBeNull();
+  });
+});

--- a/src/runtime/electron.ts
+++ b/src/runtime/electron.ts
@@ -1,0 +1,88 @@
+/**
+ * Lazy electron runtime accessors.
+ *
+ * The plugin runs as an ESM bundle loaded from `~/.lvis/plugins/...`,
+ * which is OUTSIDE Electron's `app.getAppPath()` — so a static
+ * `import { shell } from "electron"` in the bundle resolves via Node's
+ * normal ESM lookup chain, not Electron's main-process require
+ * interception, and falls through to the npm `electron` package's
+ * `index.js` (downloader stub) at `lvis-app/node_modules/electron/`.
+ * That stub throws "Electron failed to install correctly" on first
+ * import.
+ *
+ * Workaround: lazy `createRequire(import.meta.url)("electron")` runs
+ * AFTER the bundle has loaded and goes through Node's CJS resolver
+ * which Electron DOES patch. `["electron"].join("")` defeats bundler
+ * static analysis so the require literal isn't substituted at build
+ * time. Same pattern previously inlined in `lvis-plugin-ms-graph`
+ * (`src/auth/electron-runtime.ts`) and `lvis-plugin-agent-hub`
+ * (`src/auth/token-store.ts`) — extracted here so the third + nth
+ * OAuth plugin doesn't re-implement the trick.
+ *
+ * Test seam: `vi.mock("electron", ...)` does NOT intercept
+ * `createRequire("electron")` — it only hooks ESM imports, not CJS
+ * require. Tests inject mocks via the `__set*ForTests` seams below.
+ *
+ * Override sentinel convention: `undefined` = no override (use real
+ * lookup), `null` = override-to-null (electron unavailable),
+ * concrete impl = override-to-mock. Production callers must treat
+ * the returned `null` as "encryption / external-open unavailable" and
+ * degrade gracefully.
+ */
+
+import { createRequire } from "node:module";
+
+export interface SafeStorage {
+  isEncryptionAvailable: () => boolean;
+  encryptString: (s: string) => Buffer;
+  decryptString: (b: Buffer) => string;
+}
+
+export interface ShellApi {
+  openExternal: (url: string) => Promise<void>;
+}
+
+const nodeRequire = createRequire(import.meta.url);
+const electronModuleName = ["electron"].join("");
+
+let _testSafeStorageOverride: SafeStorage | null | undefined = undefined;
+let _testShellOverride: ShellApi | null | undefined = undefined;
+
+/** @internal Test seam — production code MUST NOT call this. */
+export function __setSafeStorageForTests(
+  impl: SafeStorage | null | undefined,
+): void {
+  _testSafeStorageOverride = impl;
+}
+
+/** @internal Test seam — production code MUST NOT call this. */
+export function __setShellForTests(impl: ShellApi | null | undefined): void {
+  _testShellOverride = impl;
+}
+
+export function getSafeStorage(): SafeStorage | null {
+  if (_testSafeStorageOverride !== undefined) return _testSafeStorageOverride;
+  try {
+    const electron = nodeRequire(electronModuleName) as {
+      safeStorage?: SafeStorage;
+    };
+    return electron.safeStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Returns `null` when electron cannot be resolved (e.g. test environment
+// without seam, or a broken install). Callers should surface a domain
+// error rather than letting an unhandled throw bubble up.
+export function getShell(): ShellApi | null {
+  if (_testShellOverride !== undefined) return _testShellOverride;
+  try {
+    const electron = nodeRequire(electronModuleName) as {
+      shell?: ShellApi;
+    };
+    return electron.shell ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/runtime/electron.ts
+++ b/src/runtime/electron.ts
@@ -51,16 +51,25 @@ const electronModuleName = ["electron"].join("");
 let _testSafeStorageOverride: SafeStorage | null | undefined = undefined;
 let _testShellOverride: ShellApi | null | undefined = undefined;
 
-// Runtime guard so a misbehaving (or compromised) plugin can't call
-// the test seam in a packaged build to hijack token storage. The
-// `__set*ForTests` exports are reachable via the public subpath
+// Runtime guard so a misbehaving plugin can't call the test seam in
+// a packaged build to hijack token storage. The `__set*ForTests`
+// exports are reachable via the public subpath
 // (`@lvis/plugin-sdk/runtime/electron`) — `@internal` JSDoc + `__`
 // prefix are convention-only, this guard is the actual enforcement.
 //
 // Allow-listed envs: vitest sets `VITEST=true`; tests that exercise
 // this module from outside vitest can opt in via `LVIS_TEST=1`. The
 // host's production builds set `NODE_ENV=production`; in that case
-// any seam call throws regardless of process state.
+// any seam call throws.
+//
+// Threat-model note: a determined compromised plugin running in the
+// same process can mutate `process.env.LVIS_TEST = "1"` before calling
+// the seam to bypass this guard. That's accepted — at the point a
+// plugin has code execution to mutate process env, it also has
+// `createRequire("electron")` directly + `require.cache` poisoning +
+// every other in-process attack primitive available. This guard
+// targets accidental misuse (a plugin author copy-pastes a test
+// helper into production code), not a determined attacker.
 function assertTestEnvironment(name: string): void {
   if (
     typeof process !== "undefined" &&

--- a/src/runtime/electron.ts
+++ b/src/runtime/electron.ts
@@ -45,18 +45,48 @@ export interface ShellApi {
 const nodeRequire = createRequire(import.meta.url);
 const electronModuleName = ["electron"].join("");
 
+// Module-level seam state. Pinned to vitest `pool: "forks"` per-file
+// isolation in vitest.config.ts so concurrent test files can't stomp
+// each other's overrides — see that comment for the rationale.
 let _testSafeStorageOverride: SafeStorage | null | undefined = undefined;
 let _testShellOverride: ShellApi | null | undefined = undefined;
+
+// Runtime guard so a misbehaving (or compromised) plugin can't call
+// the test seam in a packaged build to hijack token storage. The
+// `__set*ForTests` exports are reachable via the public subpath
+// (`@lvis/plugin-sdk/runtime/electron`) — `@internal` JSDoc + `__`
+// prefix are convention-only, this guard is the actual enforcement.
+//
+// Allow-listed envs: vitest sets `VITEST=true`; tests that exercise
+// this module from outside vitest can opt in via `LVIS_TEST=1`. The
+// host's production builds set `NODE_ENV=production`; in that case
+// any seam call throws regardless of process state.
+function assertTestEnvironment(name: string): void {
+  if (
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.NODE_ENV === "production" &&
+    !process.env.VITEST &&
+    !process.env.LVIS_TEST
+  ) {
+    throw new Error(
+      `${name}: test seam called in production. ` +
+      `Use vitest, set LVIS_TEST=1, or remove the call.`,
+    );
+  }
+}
 
 /** @internal Test seam — production code MUST NOT call this. */
 export function __setSafeStorageForTests(
   impl: SafeStorage | null | undefined,
 ): void {
+  assertTestEnvironment("__setSafeStorageForTests");
   _testSafeStorageOverride = impl;
 }
 
 /** @internal Test seam — production code MUST NOT call this. */
 export function __setShellForTests(impl: ShellApi | null | undefined): void {
+  assertTestEnvironment("__setShellForTests");
   _testShellOverride = impl;
 }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "ui/index": "src/ui/index.ts",
     "ui/tokens/index": "src/ui/tokens/index.ts",
     "build/tsup": "src/build/tsup.ts",
+    "runtime/electron": "src/runtime/electron.ts",
   },
   format: ["esm"],
   // dts emission is delegated to `tsc -p tsconfig.build.json` (see package.json

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,13 @@ export default defineConfig({
     environment: "jsdom",
     include: ["src/**/__tests__/**/*.{test,spec}.ts", "__tests__/**/*.{test,spec}.ts"],
     testTimeout: 10000,
+    // Pin per-file isolation. `src/runtime/electron.ts` carries module-
+    // level test-seam state (`_testSafeStorageOverride`,
+    // `_testShellOverride`); a future switch to `pool: "threads"` with
+    // `isolate: false` would let two test files alternately stomp the
+    // override and produce flaky "encryption not available" failures.
+    // `forks` is vitest's default but we make it explicit so a
+    // contributor can't silently regress the contract.
+    pool: "forks",
   },
 });


### PR DESCRIPTION
## 요약

\`lvis-plugin-ms-graph\` (\`src/auth/electron-runtime.ts\`) 와 \`lvis-plugin-agent-hub\` (\`src/auth/token-store.ts\`) 에서 각각 inline 으로 구현돼있던 lazy-electron 패턴을 SDK 로 추출. 향후 OAuth 플러그인 (#3, #4 …) 가 같은 트릭을 재발견하지 않도록 단일 소스로 유지.

## 동기

ESM \`import \"electron\"\` 가 \`~/.lvis/plugins/...\` (= \`app.getAppPath()\` 외부) 에서 로드되면 Electron main-process require interception 을 우회해서 npm \`electron\` downloader stub 으로 떨어짐 → \"Electron failed to install correctly\". lazy \`createRequire(import.meta.url)(\"electron\")\` 는 Node CJS resolver 를 거쳐서 Electron 패치를 받음.

번들러 static-analysis 회피 (\`[\"electron\"].join(\"\")\`) 는 비명시적이라 매 플러그인이 잊을 위험. 중앙화해서 한 번에 맞춰둠.

## Public API

\`@lvis/plugin-sdk/runtime/electron\`:

\`\`\`ts
export interface SafeStorage { ... }
export interface ShellApi { openExternal: (url: string) => Promise<void>; }

export function getSafeStorage(): SafeStorage | null;
export function getShell(): ShellApi | null;

/** @internal */
export function __setSafeStorageForTests(impl: SafeStorage | null | undefined): void;
/** @internal */
export function __setShellForTests(impl: ShellApi | null | undefined): void;
\`\`\`

- 양쪽 accessor 모두 electron 미해소 시 \`null\` 반환 (throw 안 함). caller 는 localized domain error 로 fail-graceful.
- Tri-state seam convention: \`undefined\` = passthrough, \`null\` = 강제 unavailable, concrete impl = mock.
- \`vi.mock(\"electron\")\` 은 \`createRequire(\"electron\")\` 를 가로채지 못함 — 명시적 seam 필수.

## 변경 내용

- \`src/runtime/electron.ts\` 신규
- \`tsup.config.ts\` entry 에 \`runtime/electron\` 추가
- \`package.json\` exports map 에 \`./runtime/electron\` 추가, version 3.4.2 → 3.5.0
- \`src/__tests__/runtime-electron.test.ts\` 신규 (9 tests)

## 검증

- \`bun run build\` → \`dist/runtime/electron.js\` (934B) + \`.d.ts\` 생성
- \`bun run test\` → 159 passed (150 prior + 9 신규)
- typecheck clean

## 후속 (이 PR 머지 + v3.5.0 tag 후 별도 PR)

- \`lvis-plugin-ms-graph\`: \`src/auth/electron-runtime.ts\` 제거 → SDK import 로 교체. PR #87 (open) 에 묶을 수 있음.
- \`lvis-plugin-agent-hub\`: \`src/auth/token-store.ts\` 의 inline 패턴 제거 → SDK import.

## Test plan

- [x] \`bun run build\` 통과 + dist/ 산물 확인
- [x] \`bun run test\` 통과 (9 신규)
- [x] typecheck clean
- [ ] 머지 후 v3.5.0 tag → 후속 ms-graph + agent-hub 마이그레이션 PR

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)