### PR TITLE
feat(schema): add pluginAccess.agentApprovalScopes (§8 P0 #71)

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -413,7 +413,8 @@
         },
         "agentApprovalScopes": {
           "type": "array",
-          "description": "§8 P0 security — approval action scopes this plugin is permitted to issue and respond to via hostApi.agentApproval. Empty array (default when omitted) means no approval scopes allowed. Known values: 'agent_file_share', 'agent_task_delegate', 'agent_external_api_call'.",
+          "description": "§8 P0 security — approval action scopes this plugin is permitted to issue and respond to via hostApi.agentApproval. Omitted or empty array means no approval scopes allowed (host enforces empty-list semantics). Known values: 'agent_file_share', 'agent_task_delegate', 'agent_external_api_call'.",
+          "default": [],
           "items": {
             "type": "string",
             "minLength": 1,

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -410,6 +410,16 @@
               }
             }
           }
+        },
+        "agentApprovalScopes": {
+          "type": "array",
+          "description": "§8 P0 security — approval action scopes this plugin is permitted to issue and respond to via hostApi.agentApproval. Empty array (default when omitted) means no approval scopes allowed. Known values: 'agent_file_share', 'agent_task_delegate', 'agent_external_api_call'.",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "uniqueItems": true
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export interface PluginAccessTarget {
 
 export interface PluginAccessSpec {
   plugins: PluginAccessTarget[];
+
+  agentApprovalScopes?: string[];
 }
 
 /**
@@ -661,6 +663,13 @@ export interface PluginHostApi {
   triggerConversation(spec: ConversationTriggerSpec): Promise<ConversationTriggerResult>;
 
   agentApproval: {
+
+    request(input: {
+      toolName: string;
+      args: unknown;
+      reason: string;
+      scope: string;
+    }): Promise<ApprovalChoice>;
 
     respond(requestId: string, choice: ApprovalChoice, nonce?: string, hmac?: string): Promise<void>;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,14 @@ export interface PluginAccessTarget {
 
 export interface PluginAccessSpec {
   plugins: PluginAccessTarget[];
+  /**
+   * §8 P0 security — approval action scopes this plugin is permitted to
+   * issue and respond to via `hostApi.agentApproval.{request,respond}`.
+   * Omitted or empty array means no approval scopes allowed (host enforces
+   * empty-list semantics). Known values: `agent_file_share`,
+   * `agent_task_delegate`, `agent_external_api_call`.
+   */
+  agentApprovalScopes?: string[];
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,14 +51,6 @@ export interface PluginAccessTarget {
 
 export interface PluginAccessSpec {
   plugins: PluginAccessTarget[];
-  /**
-   * §8 P0 security — approval action scopes this plugin is permitted to
-   * issue and respond to via `hostApi.agentApproval.{request,respond}`.
-   * Omitted or empty array means no approval scopes allowed (host enforces
-   * empty-list semantics). Known values: `agent_file_share`,
-   * `agent_task_delegate`, `agent_external_api_call`.
-   */
-  agentApprovalScopes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Companion to lvis-project/lvis-app#533 (§8 P0 agent approval IPC origin gating).

- Extends `pluginAccess` JSON Schema with `agentApprovalScopes: string[]` (optional, unique items, pattern `^[a-z][a-z0-9_]*$`)
- AJV validates that declared scope values conform to the naming convention
- Default omitted = empty = no approval scopes permitted (secure default)

## Companion PRs

- **lvis-app**: lvis-project/lvis-app#533
- **lvis-plugin-agent-hub**: `feat/agent-approval-scopes-manifest`

## Test plan

- [ ] AJV schema compiles without errors
- [ ] `agent-hub` `plugin.json` with `agentApprovalScopes` passes AJV validation
- [ ] `plugin.json` without `agentApprovalScopes` still passes (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)