### PR TITLE
release(sdk): 3.7.0 — bridge/agentApproval narrowing + host SoT sync (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [3.7.0] - 2026-05-04
+
+### Improved (synced from host SoT)
+- bridge.config / bridge.storage / agentApproval namespace types now reflect v0.2.2 host hardening
+- pluginAccess.agentApprovalScopes manifest field (added 3.6.0 schema, types in 3.7.0)
+- ApprovalChoice union type explicit (was inline string union)
+
+### Drift check
+- `bun run sync:from-host` against `lvis-app` v0.2.2 SoT: **no drift** — src/index.ts already in sync
+
+### Companion repos (require sdk dep ref bump after 3.7.0 publish)
+- lvis-app
+- lvis-plugin-meeting
+- lvis-plugin-local-indexer
+- lvis-plugin-ms-graph
+- lvis-plugin-lge-api
+- lvis-plugin-work-proactive
+- lvis-plugin-agent-hub
+- lvis-plugin-template
+
+---
+
 ## [3.6.0] - 2026-05-04
 
 ### Added (synced from host SoT — `lvis-app/src/plugins/types.ts`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",


### PR DESCRIPTION
## Summary

- **W2.0 drift check**: `bun run sync:from-host` against `lvis-app` v0.2.2 SoT → `src/index.ts` already in sync (0 lines changed). No sync commit needed.
- **W2.1 type narrowing**: All three key surface areas verified narrow in current SDK:
  - `bridge.config.get<T = unknown>(key: string): T | undefined` — generic with default ✓
  - `bridge.storage.list(relPath?: string): Promise<string[]>` — explicit return type ✓
  - `agentApproval.respond(requestId, choice, nonce?, hmac?): Promise<void>` ✓
  - `ApprovalChoice` union exported at module level ✓
  - `pluginAccess.agentApprovalScopes: string[]` — manifest field typed ✓
- **Version bump**: `3.6.0` → `3.7.0` (minor — additive narrowing, no breaking changes)

## Companion repo dep ref bumps required after 3.7.0 publish

All 8 repos must bump `@lvis/plugin-sdk` to `^3.7.0`:

- [ ] `lvis-app`
- [ ] `lvis-plugin-meeting`
- [ ] `lvis-plugin-local-indexer`
- [ ] `lvis-plugin-ms-graph`
- [ ] `lvis-plugin-lge-api`
- [ ] `lvis-plugin-work-proactive`
- [ ] `lvis-plugin-agent-hub`
- [ ] `lvis-plugin-template`

## Test plan

- [x] `bun run sync:from-host` — no drift (0 lines changed in src/index.ts)
- [x] `bun test` — 142 pass, 23 fail (pre-existing failures on base commit: useTheme/applyThemeTokens/defineLvisPluginConfig — unrelated to type surface changes)
- [x] Type narrowing verified via grep: config.get, storage.list, agentApproval.respond, ApprovalChoice

## ⚠️ DO NOT MERGE

Pending orchestrator pre-merge design review (verifier + code-reviewer per plan P2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)