### PR TITLE
feat(sdk): remove addTask from PluginHostApi — v3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -738,7 +738,6 @@ describe("PluginHostApi — interface contract (structural)", () => {
       onEvent: (_type, _handler) => () => {},
       getInstalledPluginIds: () => [],
       onPluginsChanged: (_handler) => () => {},
-      addTask: (_task) => {},
       getSecret: (_key) => null,
       callTool: (_name, _payload) => Promise.resolve(undefined) as Promise<never>,
       callLlm: async (_prompt, _opts) => "",
@@ -841,19 +840,6 @@ describe("PluginHostApi — interface contract (structural)", () => {
     expect(classify({ type: "uninstalled", pluginId: "x" })).toBe("uninstall");
   });
 
-  it("PluginHostApi.addTask accepts all priority levels", () => {
-    const tasks: Parameters<PluginHostApi["addTask"]>[0][] = [];
-    const api: Pick<PluginHostApi, "addTask"> = {
-      addTask: (t) => { tasks.push(t); },
-    };
-    api.addTask({ title: "A", source: "plugin:test", priority: "high" });
-    api.addTask({ title: "B", source: "plugin:test", priority: "medium" });
-    api.addTask({ title: "C", source: "plugin:test", priority: "low" });
-    api.addTask({ title: "D", source: "plugin:test" }); // optional priority
-    expect(tasks).toHaveLength(4);
-    expect(tasks[0].priority).toBe("high");
-    expect(tasks[3].priority).toBeUndefined();
-  });
 });
 
 // ─── auth cross-field invariant (H6) ───────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -598,20 +598,6 @@ export interface PluginHostApi {
    */
   onPluginsChanged(handler: (event: PluginLifecycleEvent) => void): () => void;
   /**
-   * Create a task in the host's task list.
-   *
-   * @param task - Task metadata. `source` identifies the originating plugin
-   *               or feature; `sourceRef` is an optional stable pointer back
-   *               to the originating entity (for example an email id).
-   */
-  addTask(task: {
-    title: string;
-    description?: string;
-    source: string;
-    sourceRef?: string;
-    priority?: "high" | "medium" | "low";
-  }): void;
-  /**
    * Retrieve an encrypted secret previously stored by the host or the user
    * (for example an API key).
    *


### PR DESCRIPTION
## Summary

Host task system removed in lvis-app Phase 4 (PR #551). `PluginHostApi.addTask` is no longer implemented by the host.

## Changes
- Remove `addTask` method from `PluginHostApi` interface (`src/index.ts`)
- Remove `addTask` test block and mock usage (`src/__tests__/index.test.ts`)
- Bump version to 3.8.1

## Migration
Plugins that called `hostApi.addTask()` (e.g. `lvis-plugin-meeting`) must migrate to agent-hub task creation mechanisms. Tracked in lvis-project/lvis-plugin-meeting.

## Breaking Change
`PluginHostApi.addTask` removed from interface. SDK consumers must remove calls before upgrading pin.