### PR TITLE
release(sdk): 3.9.0 — Stack/Inline + dist regeneration on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [3.9.0] - 2026-05-05
+
+### Added
+- **`Stack` and `Inline` layout primitives** (PR #98) — first composite
+  primitive in the SDK UI. Vertical / horizontal flex containers with
+  `gap`, `align`, `justify`, `wrap`, and `as` props. Hardcoded rem
+  spacing scale (xs/sm/md/lg/xl) — to be migrated to design tokens
+  when a `--lvis-spacing-*` SoT lands.
+
+### Changed (build path)
+- **dist/ no longer committed** (PR #99). The `prepare` lifecycle script
+  now runs `tsup && tsc -p tsconfig.build.json`, regenerating dist on
+  every consumer `bun install`. Eliminates two recurring CI pain points:
+  TypeScript-side `.d.ts.map` OS drift between Linux and macOS, and
+  the rebase tax on PRs whenever main moved an exported type. Consumer
+  install is ~1-2s slower; that cost is dwarfed by the saved PR cycles.
+
+## [3.8.1] - 2026-05-05
+
+### Removed (BREAKING)
+- **`PluginHostApi.addTask`** removed from interface (PR #97). Host task
+  system removed in lvis-app Phase 4 (PR #551). Plugins that created
+  tasks via `addTask` (e.g. meeting plugin) must migrate to agent-hub
+  task creation tools.
+
 ## [3.8.0] - 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",


### PR DESCRIPTION
## 요약

PR #98 (Stack/Inline) + PR #99 (dist regen on install) 묶어서 v3.9.0 릴리즈 + v3.8.1 (PR #97 addTask 제거) 의 retroactive CHANGELOG 노트 보강.

## 포함된 변경

**v3.9.0**
- 🧱 `Stack` / `Inline` layout primitive (첫 composite primitive)
- 🛠 `prepare` = `tsup && tsc -p tsconfig.build.json` — 컨슈머가 `bun install` 시 dist 자체 생성. 커밋된 dist 폐지로 PR rebase tax + OS-level `.d.ts.map` drift 둘 다 원천 해결

**v3.8.1 retroactive note** (PR #97 — 이미 태그됨)
- `PluginHostApi.addTask` 제거 (BREAKING). 호스트 task 시스템이 lvis-app PR #551 에서 제거됨

## 후속

- 본 PR 머지 후 `git tag v3.9.0 && git push origin v3.9.0` → release.yml 이 자동 GitHub Release 생성
- work-proactive PR (다음 step) 가 v3.9.0 핀으로 detector-control 마이그레이션 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)