### PR TITLE
fix(ui): auto-inject :root 토큰 fallback — 첫 프레임 invisible 회귀 차단 (v3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [3.9.1] - 2026-05-05
+
+### Fixed
+- **`:root` token fallback now auto-injects on `@lvis/plugin-sdk/ui` import.**
+  Plugin webviews previously rendered SDK components with `var(--lvis-*)`
+  resolving to the CSS `initial` keyword (i.e. invisible — Toggle thumb
+  white-on-white) during the brief window between mount and the host's
+  first `host.theme.changed` broadcast. Observed when entering a plugin
+  panel for the first time after app launch — toggling the theme reset
+  unstuck it. The fallback module emits a `:root { --lvis-*: ... }`
+  block via `injectTokenCss` at module load (matching the values in
+  `lvis-tokens.css :root` and the host's `_DARK_BASE` token map) so
+  components paint with sensible dark-mode tokens immediately. The
+  host's broadcast still wins via inline `style.setProperty` once it
+  arrives.
+
 ## [3.9.0] - 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,3 +1,12 @@
+// Side-effect: inject `:root` fallback token values so `var(--lvis-*)`
+// resolves to a sensible dark-mode palette during the brief window
+// between plugin webview mount and the host's first `host.theme.changed`
+// broadcast. Without this, components like Toggle render invisible
+// (CSS `initial` for unknown variables) until the user toggles the
+// theme. Must run before any component module's `injectTokenCss` so
+// the `<style>` order stays predictable in <head>.
+import "./tokens/fallback.js";
+
 export * from "./components/index.js";
 export * from "./hooks/useTheme.js";
 export * from "./tokens/index.js";

--- a/src/ui/tokens/fallback.ts
+++ b/src/ui/tokens/fallback.ts
@@ -1,0 +1,41 @@
+import { injectTokenCss } from "./inject.js";
+
+/**
+ * `:root` fallback token values. Auto-injected at module load so
+ * `var(--lvis-*)` references in component CSS resolve to a sensible
+ * dark-mode palette during the brief window between webview mount and
+ * the host's first `host.theme.changed` broadcast.
+ *
+ * Without this fallback, plugin UIs flash invisible (CSS `initial`)
+ * because `var(--lvis-*)` has no defined value until the host pushes
+ * computed tokens via the broadcast — observed as "Toggle thumb is
+ * white on white" until the user toggles the theme.
+ *
+ * Values mirror `lvis-tokens.css :root` and stay in lockstep with
+ * `lvis-app/src/ui/renderer/theme/plugin-token-map.ts _DARK_BASE`.
+ * Three places need to move together when the design palette shifts:
+ *   1. lvis-app/src/ui/renderer/theme/plugin-token-map.ts (_DARK_BASE)
+ *   2. lvis-plugin-sdk/src/ui/tokens/lvis-tokens.css (:root)
+ *   3. lvis-plugin-sdk/src/ui/tokens/fallback.ts (this file)
+ */
+const FALLBACK_CSS = `:root {
+  --lvis-bg:           hsl(222.2, 84%, 4.9%);
+  --lvis-surface:      hsl(222.2, 84%, 7%);
+  --lvis-fg:           hsl(210, 40%, 98%);
+  --lvis-fg-muted:     hsl(215, 20%, 65%);
+  --lvis-primary:      hsl(217.2, 91.2%, 59.8%);
+  --lvis-primary-fg:   hsl(210, 40%, 98%);
+  --lvis-secondary:    hsl(217, 33%, 17%);
+  --lvis-secondary-fg: hsl(210, 40%, 98%);
+  --lvis-danger:       hsl(0, 62.8%, 30.6%);
+  --lvis-danger-fg:    hsl(210, 40%, 98%);
+  --lvis-warning:      hsl(48, 97%, 77%);
+  --lvis-warning-fg:   hsl(30, 80%, 25%);
+  --lvis-success:      hsl(142, 71%, 45%);
+  --lvis-border:       hsl(217, 33%, 17%);
+  --lvis-ring:         hsl(224.3, 76.3%, 48%);
+  --lvis-radius:       0.6rem;
+  --lvis-radius-sm:    0.25rem;
+}`;
+
+injectTokenCss("lvis-tokens-fallback", FALLBACK_CSS);


### PR DESCRIPTION
## 요약

플러그인 webview 가 SDK 컴포넌트 첫 렌더 시 `var(--lvis-*)` 가 `initial` 로 해석되어 invisible 하게 그려지는 회귀 발견. work-proactive 의 detector-control 패널에서 Toggle thumb 가 흰색-위-흰색으로 안 보였고, 사용자가 테마를 토글해야만 (broadcast 강제 발생) 보임.

## 원인

SDK 컴포넌트 CSS 가 `var(--lvis-*)` 참조하는데 `:root` 기본값 inject 하는 모듈이 없음. `lvis-tokens.css` 파일은 있지만 import 안 함. 결과: host broadcast 가 도착할 때까지 모든 토큰이 CSS `initial` (= 색 없음).

## 수정

`src/ui/tokens/fallback.ts` 신규 — `:root { --lvis-*: ... }` 블록을 module 로드 시 `injectTokenCss` 로 주입. `src/ui/index.ts` 가 side-effect 로 import 하므로 `Stack` / `Card` / `Toggle` 등 어떤 SDK UI 라도 import 하면 자동 적용. 값은 `lvis-tokens.css :root` + lvis-app `_DARK_BASE` 와 일치.

호스트 broadcast 가 도착하면 inline `style.setProperty` 가 우선 적용되므로 fallback 은 첫 프레임 ~수 ms 만 사용.

## SoT lockstep (3 파일)

색 팔레트 변경 시 같이 움직여야 하는 곳:
1. `lvis-app/src/ui/renderer/theme/plugin-token-map.ts` (`_DARK_BASE`)
2. `lvis-plugin-sdk/src/ui/tokens/lvis-tokens.css` (`:root`)
3. `lvis-plugin-sdk/src/ui/tokens/fallback.ts` (신규)

향후 sync-tokens-from-host.mjs 가 fallback.ts 도 자동 갱신하도록 확장 가능 (별도 follow-up).

## 검증

- [x] `bun run test` (197/197 pass)
- [x] `bunx tsc --noEmit` (0 errors)
- [ ] e2e: 플러그인 웹뷰 열었을 때 첫 프레임에 토글 보이는지 확인 (work-proactive PR #59 머지 + SDK v3.9.1 publish 후 work-proactive 핀 bump 후 검증)

## 버전

`3.9.0 → 3.9.1` (bug fix patch)

## 후속

- 머지 + tag v3.9.1 push
- work-proactive PR #59 의 SDK 핀을 v3.9.1 로 bump (또는 같은 머지 시점에 reattach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)