### PR TITLE
refactor(ui): fallback ensure-on-inject — collapse 10-line copy-paste (v3.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.0.1] - 2026-05-05
 
+### Added
+
+- **`ensureFallback()`** — new public export from
+  `@lvis/plugin-sdk/ui/tokens/inject`. Idempotent helper that lazily injects
+  the `:root` fallback `<style id="lvis-tokens-fallback">` block. Plugins
+  that mount custom React shells before any SDK component evaluates can
+  pre-warm the fallback by calling `ensureFallback()` directly. Otherwise
+  it runs automatically on the first `injectTokenCss` call.
+
 ### Refactored — fallback ensure-on-inject (architect P0 follow-up to PR #102)
 
 - **`:root` fallback CSS moves into `inject.ts`** as an ensure-on-first-call
@@ -33,7 +42,8 @@ real maintenance smell — future contributors authoring a new component
 have to remember the side-effect import or the fallback drops. Folding
 it into `injectTokenCss` makes the contract automatic.
 
-Pure refactor — runtime behavior identical. 197/197 tests pass.
+Pure refactor — runtime behavior identical. 201/201 tests pass (4 new
+gate-coverage cases added in `inject.test.ts`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [4.0.1] - 2026-05-05
+
+### Refactored — fallback ensure-on-inject (architect P0 follow-up to PR #102)
+
+- **`:root` fallback CSS moves into `inject.ts`** as an ensure-on-first-call
+  side effect of `injectTokenCss`. The 10 `import "../tokens/fallback.js"`
+  side-effect-import lines that PR #102 added to every component
+  module are removed — the requirement collapses from "use injectTokenCss
+  AND remember the fallback import" to just "use injectTokenCss" (which
+  every component already does for its own CSS).
+- `tokens/fallback.ts` becomes a backward-compat shim — it now imports
+  the new `ensureFallback` export from `inject.ts` and calls it. Plugin
+  authors who imported `@lvis/plugin-sdk/ui/tokens/fallback` directly
+  (subpath added in 3.10.0 / re-published in 4.0.0) continue to work unchanged.
+- `ensureFallback` is exported from `inject.ts` for advanced consumers
+  who want to pre-warm the `<style>` block before any component
+  evaluates (e.g., a custom plugin shell that wants tokens applied
+  before its own React mount).
+
+### Why
+
+Architect self-review on PR #102 flagged the 10-line copy-paste as a
+real maintenance smell — future contributors authoring a new component
+have to remember the side-effect import or the fallback drops. Folding
+it into `injectTokenCss` makes the contract automatic.
+
+Pure refactor — runtime behavior identical. 197/197 tests pass.
+
+---
+
 ## [3.10.0] - 2026-05-05
 
 ### Added — per-component subpath exports (tree-shaking optimization)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/src/ui/__tests__/inject.test.ts
+++ b/src/ui/__tests__/inject.test.ts
@@ -1,60 +1,102 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { applyThemeTokens, injectTokenCss } from "../tokens/inject.js";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
-beforeEach(() => {
+type InjectModule = typeof import("../tokens/inject.js");
+let mod: InjectModule;
+
+beforeEach(async () => {
   document.documentElement.style.cssText = "";
   document.head.querySelectorAll("style[id]").forEach((el) => el.remove());
+  // `_fallbackEnsured` is module-level state — reset between tests so each
+  // case starts with a fresh ensure-on-first-call gate.
+  vi.resetModules();
+  mod = await import("../tokens/inject.js");
 });
 
 describe("applyThemeTokens", () => {
   it("applies known --lvis-* token", () => {
-    applyThemeTokens({ "--lvis-bg": "#ffffff" });
+    mod.applyThemeTokens({ "--lvis-bg": "#ffffff" });
     expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("#ffffff");
   });
 
   it("drops unknown key", () => {
-    applyThemeTokens({ "--evil-key": "red" });
+    mod.applyThemeTokens({ "--evil-key": "red" });
     expect(document.documentElement.style.getPropertyValue("--evil-key")).toBe("");
   });
 
   it("drops url() injection value", () => {
-    applyThemeTokens({ "--lvis-bg": "url(https://evil.com?x=1)" });
+    mod.applyThemeTokens({ "--lvis-bg": "url(https://evil.com?x=1)" });
     expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("");
   });
 
   it("drops expression() injection value", () => {
-    applyThemeTokens({ "--lvis-bg": "expression(alert(1))" });
+    mod.applyThemeTokens({ "--lvis-bg": "expression(alert(1))" });
     expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("");
   });
 
   it("drops HTML tag injection value", () => {
-    applyThemeTokens({ "--lvis-bg": "<script>alert(1)</script>" });
+    mod.applyThemeTokens({ "--lvis-bg": "<script>alert(1)</script>" });
     expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("");
   });
 
   it("allows safe values like hex, hsl, var()", () => {
-    applyThemeTokens({ "--lvis-bg": "#0f0f13" });
+    mod.applyThemeTokens({ "--lvis-bg": "#0f0f13" });
     expect(document.documentElement.style.getPropertyValue("--lvis-bg")).toBe("#0f0f13");
-    applyThemeTokens({ "--lvis-fg": "hsl(0 0% 95%)" });
+    mod.applyThemeTokens({ "--lvis-fg": "hsl(0 0% 95%)" });
     expect(document.documentElement.style.getPropertyValue("--lvis-fg")).toBe("hsl(0 0% 95%)");
   });
 
   it("does not block CSS math expressions without HTML tags", () => {
-    applyThemeTokens({ "--lvis-radius": "clamp(0.25rem, 1vw, 0.5rem)" });
+    mod.applyThemeTokens({ "--lvis-radius": "clamp(0.25rem, 1vw, 0.5rem)" });
     expect(document.documentElement.style.getPropertyValue("--lvis-radius")).toBe("clamp(0.25rem, 1vw, 0.5rem)");
   });
 });
 
 describe("injectTokenCss", () => {
   it("injects a style tag with the given id", () => {
-    injectTokenCss("test-style", ":root { --x: 1; }");
+    mod.injectTokenCss("test-style", ":root { --x: 1; }");
     expect(document.getElementById("test-style")?.textContent).toBe(":root { --x: 1; }");
   });
 
   it("updates content on re-inject (HMR)", () => {
-    injectTokenCss("test-style", ":root { --x: 1; }");
-    injectTokenCss("test-style", ":root { --x: 2; }");
+    mod.injectTokenCss("test-style", ":root { --x: 1; }");
+    mod.injectTokenCss("test-style", ":root { --x: 2; }");
     expect(document.getElementById("test-style")?.textContent).toBe(":root { --x: 2; }");
     expect(document.head.querySelectorAll("#test-style").length).toBe(1);
+  });
+});
+
+describe("ensureFallback (gate semantics — 3.10.1)", () => {
+  it("first injectTokenCss call ensures the :root fallback <style>", () => {
+    expect(document.getElementById("lvis-tokens-fallback")).toBeNull();
+    mod.injectTokenCss("c1", ":root { --x: 1; }");
+    const fb = document.getElementById("lvis-tokens-fallback");
+    expect(fb).not.toBeNull();
+    expect(fb?.textContent).toContain("--lvis-bg:");
+    expect(fb?.textContent).toContain("--lvis-radius:");
+  });
+
+  it("multiple injectTokenCss calls produce exactly one fallback <style>", () => {
+    mod.injectTokenCss("c1", ":root { --x: 1; }");
+    mod.injectTokenCss("c2", ":root { --y: 2; }");
+    mod.injectTokenCss("c3", ":root { --z: 3; }");
+    expect(document.head.querySelectorAll("#lvis-tokens-fallback").length).toBe(1);
+  });
+
+  it("preserves a pre-existing #lvis-tokens-fallback (host-injected) without overwrite", () => {
+    const pre = document.createElement("style");
+    pre.id = "lvis-tokens-fallback";
+    pre.textContent = ":root { --lvis-bg: hostvalue; }";
+    document.head.appendChild(pre);
+    mod.injectTokenCss("c1", ":root { --x: 1; }");
+    const fb = document.getElementById("lvis-tokens-fallback");
+    expect(fb?.textContent).toBe(":root { --lvis-bg: hostvalue; }");
+    expect(document.head.querySelectorAll("#lvis-tokens-fallback").length).toBe(1);
+  });
+
+  it("ensureFallback() is idempotent — repeated calls no-op", () => {
+    mod.ensureFallback();
+    mod.ensureFallback();
+    mod.ensureFallback();
+    expect(document.head.querySelectorAll("#lvis-tokens-fallback").length).toBe(1);
   });
 });

--- a/src/ui/components/Badge.tsx
+++ b/src/ui/components/Badge.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Card.tsx
+++ b/src/ui/components/Card.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Checkbox.tsx
+++ b/src/ui/components/Checkbox.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Input.tsx
+++ b/src/ui/components/Input.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Select.tsx
+++ b/src/ui/components/Select.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 export type SpinnerSize = "sm" | "md" | "lg";

--- a/src/ui/components/Stack.tsx
+++ b/src/ui/components/Stack.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 // Spacing scale is hardcoded in rems rather than read from design

--- a/src/ui/components/Text.tsx
+++ b/src/ui/components/Text.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/components/Toggle.tsx
+++ b/src/ui/components/Toggle.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "../tokens/fallback.js";
 import { injectTokenCss } from "../tokens/inject.js";
 
 const CSS = `

--- a/src/ui/tokens/fallback.ts
+++ b/src/ui/tokens/fallback.ts
@@ -1,41 +1,18 @@
-import { injectTokenCss } from "./inject.js";
+import { ensureFallback } from "./inject.js";
 
 /**
- * `:root` fallback token values. Auto-injected at module load so
- * `var(--lvis-*)` references in component CSS resolve to a sensible
- * dark-mode palette during the brief window between webview mount and
- * the host's first `host.theme.changed` broadcast.
+ * Backward-compat shim (3.10.1+).
  *
- * Without this fallback, plugin UIs flash invisible (CSS `initial`)
- * because `var(--lvis-*)` has no defined value until the host pushes
- * computed tokens via the broadcast — observed as "Toggle thumb is
- * white on white" until the user toggles the theme.
+ * The `:root` fallback CSS used to live here as a top-level
+ * `injectTokenCss` side effect, and every component file added
+ * `import "../tokens/fallback.js"` to ensure it ran. v3.10.1 collapsed
+ * that 10-line duplication into `injectTokenCss` itself — any call to
+ * `injectTokenCss` lazily ensures the `<style id="lvis-tokens-fallback">`
+ * is present on first execution.
  *
- * Values mirror `lvis-tokens.css :root` and stay in lockstep with
- * `lvis-app/src/ui/renderer/theme/plugin-token-map.ts _DARK_BASE`.
- * Three places need to move together when the design palette shifts:
- *   1. lvis-app/src/ui/renderer/theme/plugin-token-map.ts (_DARK_BASE)
- *   2. lvis-plugin-sdk/src/ui/tokens/lvis-tokens.css (:root)
- *   3. lvis-plugin-sdk/src/ui/tokens/fallback.ts (this file)
+ * This module is kept as a public subpath (`@lvis/plugin-sdk/ui/tokens/fallback`)
+ * for plugin authors who explicitly imported it for its side effect —
+ * importing this module continues to ensure the fallback `<style>` is
+ * present, just via a different code path. Safe to keep, safe to drop.
  */
-const FALLBACK_CSS = `:root {
-  --lvis-bg:           hsl(222.2, 84%, 4.9%);
-  --lvis-surface:      hsl(222.2, 84%, 7%);
-  --lvis-fg:           hsl(210, 40%, 98%);
-  --lvis-fg-muted:     hsl(215, 20%, 65%);
-  --lvis-primary:      hsl(217.2, 91.2%, 59.8%);
-  --lvis-primary-fg:   hsl(210, 40%, 98%);
-  --lvis-secondary:    hsl(217, 33%, 17%);
-  --lvis-secondary-fg: hsl(210, 40%, 98%);
-  --lvis-danger:       hsl(0, 62.8%, 30.6%);
-  --lvis-danger-fg:    hsl(210, 40%, 98%);
-  --lvis-warning:      hsl(48, 97%, 77%);
-  --lvis-warning-fg:   hsl(30, 80%, 25%);
-  --lvis-success:      hsl(142, 71%, 45%);
-  --lvis-border:       hsl(217, 33%, 17%);
-  --lvis-ring:         hsl(224.3, 76.3%, 48%);
-  --lvis-radius:       0.6rem;
-  --lvis-radius-sm:    0.25rem;
-}`;
-
-injectTokenCss("lvis-tokens-fallback", FALLBACK_CSS);
+ensureFallback();

--- a/src/ui/tokens/inject.ts
+++ b/src/ui/tokens/inject.ts
@@ -44,6 +44,11 @@ let _fallbackEnsured = false;
 export function ensureFallback(): void {
   if (_fallbackEnsured) return;
   if (typeof document === "undefined") return;
+  // Flip the gate BEFORE the DOM mutation: fallback inject is best-effort.
+  // If `appendChild` throws (e.g. CSP `style-src` violation, frozen <head>),
+  // re-trying every subsequent injectTokenCss call would just rethrow the
+  // same error indefinitely — the host's primary `host.theme.changed`
+  // broadcast still wins via inline `style.setProperty` regardless.
   _fallbackEnsured = true;
   if (document.getElementById("lvis-tokens-fallback")) return;
   const el = document.createElement("style");

--- a/src/ui/tokens/inject.ts
+++ b/src/ui/tokens/inject.ts
@@ -5,7 +5,55 @@ const _ALLOWED_KEYS = new Set<string>(LVIS_TOKEN_NAMES);
 // rather than bare `<` to avoid false-positives on CSS math expressions.
 const _UNSAFE_VALUE = /url\s*\(|expression\s*\(|<[a-zA-Z]/i;
 
+// `:root` fallback values — kept inline here (instead of a separate
+// `fallback.ts` module) so the SINGLE entry point that every component
+// imports — `injectTokenCss` — can lazily ensure the fallback `<style>`
+// is present on first call. The prior pattern of having every component
+// file add `import "../tokens/fallback.js"` worked but smelled — 10
+// identical lines future contributors had to remember when authoring a
+// new component. With ensure-on-inject, the requirement collapses to
+// "use injectTokenCss," which is already universal.
+//
+// Values mirror `lvis-tokens.css :root` and lockstep with the host's
+// `_DARK_BASE` token map. Three places must move together when the
+// design palette shifts:
+//   1. lvis-app/src/ui/renderer/theme/plugin-token-map.ts (_DARK_BASE)
+//   2. lvis-plugin-sdk/src/ui/tokens/lvis-tokens.css (:root)
+//   3. lvis-plugin-sdk/src/ui/tokens/inject.ts (this file, _FALLBACK_CSS)
+const _FALLBACK_CSS = `:root {
+  --lvis-bg:           hsl(222.2, 84%, 4.9%);
+  --lvis-surface:      hsl(222.2, 84%, 7%);
+  --lvis-fg:           hsl(210, 40%, 98%);
+  --lvis-fg-muted:     hsl(215, 20%, 65%);
+  --lvis-primary:      hsl(217.2, 91.2%, 59.8%);
+  --lvis-primary-fg:   hsl(210, 40%, 98%);
+  --lvis-secondary:    hsl(217, 33%, 17%);
+  --lvis-secondary-fg: hsl(210, 40%, 98%);
+  --lvis-danger:       hsl(0, 62.8%, 30.6%);
+  --lvis-danger-fg:    hsl(210, 40%, 98%);
+  --lvis-warning:      hsl(48, 97%, 77%);
+  --lvis-warning-fg:   hsl(30, 80%, 25%);
+  --lvis-success:      hsl(142, 71%, 45%);
+  --lvis-border:       hsl(217, 33%, 17%);
+  --lvis-ring:         hsl(224.3, 76.3%, 48%);
+  --lvis-radius:       0.6rem;
+  --lvis-radius-sm:    0.25rem;
+}`;
+
+let _fallbackEnsured = false;
+export function ensureFallback(): void {
+  if (_fallbackEnsured) return;
+  if (typeof document === "undefined") return;
+  _fallbackEnsured = true;
+  if (document.getElementById("lvis-tokens-fallback")) return;
+  const el = document.createElement("style");
+  el.id = "lvis-tokens-fallback";
+  el.textContent = _FALLBACK_CSS;
+  document.head.appendChild(el);
+}
+
 export function injectTokenCss(id: string, css: string): void {
+  ensureFallback();
   if (typeof document === "undefined") return;
   // Check DOM directly (not a Set) so HMR re-renders pick up CSS changes.
   const existing = document.getElementById(id);


### PR DESCRIPTION
## 요약

PR #102 architect self-review R3 P0 follow-up. PR #102 가 추가한 10개 컴포넌트의 \`import \"../tokens/fallback.js\";\` 중복을 \`injectTokenCss\` 내부 ensure-on-first-call 로 통합. 새 컴포넌트 추가 시 import 빠뜨릴 위험 차단.

## 변경 내역

- \`inject.ts\`: \`_FALLBACK_CSS\` 인라인 + \`ensureFallback()\` (once-gate) + \`injectTokenCss\` 진입 시 호출
- \`fallback.ts\`: 1줄 backward-compat shim (\`ensureFallback()\` 호출). 공개 subpath \`@lvis/plugin-sdk/ui/tokens/fallback\` 그대로 작동
- 10개 컴포넌트의 fallback import 라인 제거
- \`ensureFallback\` 공개 export — advanced consumer 가 React mount 전 토큰 pre-warm 가능

## 보장

- 런타임 contract 동일 — 같은 \`<style id=\"lvis-tokens-fallback\">\`, 같은 \`<head>\` 순서, 같은 idempotency
- 197/197 vitest pass, typecheck clean, build green
- SoT lockstep 3곳: host \`_DARK_BASE\` / \`lvis-tokens.css :root\` / \`inject.ts:_FALLBACK_CSS\`

## 버전

3.10.0 → 3.10.1 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)