### PR TITLE
chore(schemas): add host:overlay to capability enum (sync drift fix)

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -187,7 +187,8 @@
           "worker-client",
           "document-indexer",
           "conversation-trigger",
-          "lifecycle-observer"
+          "lifecycle-observer",
+          "host:overlay"
         ]
       }
     },


### PR DESCRIPTION
## Summary

Adds `host:overlay` to the AJV capability enum in \`schemas/plugin-manifest.schema.json\`.

## Background

PR #626 (lvis-app Routine v2) added \`host:overlay\` to \`KNOWN_CAPABILITIES\` (Q11 Overlay Runner) but the SDK's hand-maintained schema enum was not updated. The drift guard test in lvis-app (\`src/plugins/__tests__/capability-schema-sync.test.ts\`) fails:

\`\`\`
× capability schema/runtime sync > schema enum equals KNOWN_CAPABILITIES
  → expected [ 'host:overlay' ] to deeply equal []
\`\`\`

## Effect of the drift

Any plugin manifest declaring \`host:overlay\` is rejected at schema validation step 2 BEFORE the runtime capability gate ever runs — feature looks broken with no useful error.

## Test plan

- [x] JSON validates (\`python3 -c \"import json; json.load(open('schemas/plugin-manifest.schema.json'))\"\`)
- [ ] After merge → bump SDK pin in lvis-app → \`capability-schema-sync\` test passes

## Related

- Fixes drift introduced by lvis-app#626
- Unblocks lvis-app#632 (Q12 permission policy) — currently failing this drift test

🤖 Generated with [Claude Code](https://claude.com/claude-code)