### PR TITLE
chore: release plugin SDK v5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [5.0.2] - 2026-05-10
+
+### Fixed
+
+- Published the manifest schema capability enum update from PR #125 so consumers can validate plugins declaring `host:overlay`.
+
 ## [5.0.1] - 2026-05-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",


### PR DESCRIPTION
## Summary\n- bump @lvis/plugin-sdk to 5.0.2\n- document that the tagged release includes the host:overlay manifest schema capability enum from PR #125\n\n## Scope\n- lvis-app dependency is intentionally not touched while app PR #632 is in flight\n\n## Validation\n- bun run build\n- bun run check:dist-drift\n- bun run test\n- LVIS_HOST_REPO_ROOT=/Users/ken/workspace/GIT/github/lvis-project/lvis-app bun run check:drift\n- schema assertion: host:overlay=true\n\n## Not run\n- bun run check:schema-drift: current lvis-app checkout no longer exposes schemas/plugin.schema.json at the script's legacy path\n