### PR TITLE
feat(manifest): add toolSchemas[*].writesToOwnSandbox field (#664 P1, sibling of lvis-app#860)

### DIFF
--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -577,6 +577,10 @@
             },
             "uniqueItems": true
           },
+          "writesToOwnSandbox": {
+            "type": "boolean",
+            "description": "Issue #664 P1 (lvis-app PR #860) — sandbox-write auto-LOW self-attestation. When true, every value resolved through pathFields must stay inside ~/.lvis/plugins/<pluginId>/. The host reviewer treats sandbox-local writes as LOW risk. The runtime canonicalizes and verifies the containment claim at invocation time — a tool that emits a path outside its own sandbox falls back to the standard write rules. Use for plugins that persist sandbox-local caches (e.g. MSAL token cache) without round-tripping the user."
+          },
           "inputSchema": {
             "type": "object",
             "required": [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -176,7 +176,8 @@ describe("PluginManifest — schema validation", () => {
       };
       const { valid, errors } = validateManifest(m);
       expect(valid).toBe(false);
-      expect(errors.join("|")).toMatch(/writesToOwnSandbox/);
+      expect(errors.some((e) => e.includes("/writesToOwnSandbox"))).toBe(true);
+      expect(errors.some((e) => /must be boolean/.test(e))).toBe(true);
     });
 
     it("accepts manifest without writesToOwnSandbox (optional field)", () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -123,6 +123,68 @@ describe("PluginManifest — schema validation", () => {
     expect(validateManifest(hostOnlyMeta).valid).toBe(false);
   });
 
+  // Issue #664 P1 / PR #860 — sandbox-write self-attestation flag contract.
+  describe("toolSchemas[*].writesToOwnSandbox — type contract", () => {
+    const SANDBOX_BASE: PluginManifest = {
+      ...VALID_MINIMAL,
+      toolSchemas: {
+        my_plugin_ping: {
+          description: "Ping the plugin and return a status object.",
+          category: "write",
+          inputSchema: { type: "object", properties: {} },
+        },
+      },
+    };
+
+    it("accepts writesToOwnSandbox: true (sandbox-local cache opt-in)", () => {
+      const m = {
+        ...SANDBOX_BASE,
+        toolSchemas: {
+          my_plugin_ping: {
+            ...SANDBOX_BASE.toolSchemas!.my_plugin_ping,
+            writesToOwnSandbox: true,
+          },
+        },
+      };
+      const { valid, errors } = validateManifest(m);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+
+    it("accepts writesToOwnSandbox: false (explicit opt-out)", () => {
+      const m = {
+        ...SANDBOX_BASE,
+        toolSchemas: {
+          my_plugin_ping: {
+            ...SANDBOX_BASE.toolSchemas!.my_plugin_ping,
+            writesToOwnSandbox: false,
+          },
+        },
+      };
+      const { valid, errors } = validateManifest(m);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+
+    it("rejects writesToOwnSandbox: \"true\" (string — type contract)", () => {
+      const m = {
+        ...SANDBOX_BASE,
+        toolSchemas: {
+          my_plugin_ping: {
+            ...SANDBOX_BASE.toolSchemas!.my_plugin_ping,
+            writesToOwnSandbox: "true",
+          },
+        },
+      };
+      const { valid, errors } = validateManifest(m);
+      expect(valid).toBe(false);
+      expect(errors.join("|")).toMatch(/writesToOwnSandbox/);
+    });
+
+    it("accepts manifest without writesToOwnSandbox (optional field)", () => {
+      const { valid, errors } = validateManifest(SANDBOX_BASE);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+  });
+
   it("rejects manifest missing required field: id", () => {
     const { id: _, ...noId } = VALID_MINIMAL;
     const { valid } = validateManifest(noId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,31 @@ export interface PluginManifest {
 
       pathFields?: string[];
 
+      /**
+       * Issue #664 P1 (lvis-app PR #860) — sandbox-write auto-LOW self-attestation.
+       *
+       * When `true`, this tool promises that every value resolved through
+       * `pathFields` will stay inside the owning plugin's sandbox root
+       * (`~/.lvis/plugins/<pluginId>/`). The host reviewer (Layer 5) treats
+       * a sandbox-local write as LOW risk and skips the reviewer-lane
+       * round-trip that would otherwise queue the call in the deferred
+       * queue under headless flow.
+       *
+       * Sound-by-construction: the runtime canonicalizes (`..`, NFD, mixed
+       * case, trailing slash) and verifies the path-containment claim at
+       * invocation time. A tool that declares `true` but emits a path
+       * outside its own sandbox falls back to the standard write rules.
+       *
+       * Use case: plugins like `lvis-plugin-ms-graph` that persist an MSAL
+       * token cache to their own sandbox. Without this flag the host's
+       * `allowedDirectories` does not include plugin sandboxes by design
+       * (§5 file-based memory isolation), so the write would otherwise hit
+       * the "write outside allowed dirs" HIGH rule.
+       *
+       * @optional
+       */
+      writesToOwnSandbox?: boolean;
+
       /** Optional stable SemVer (MAJOR.MINOR.PATCH) for this tool — §6.4 Tool versioning. Falls back to the manifest top-level `version` when omitted. @optional */
       version?: string;
 


### PR DESCRIPTION
## Summary

Companion to lvis-project/lvis-app#860 — SDK side exposes the `writesToOwnSandbox?: boolean` field on `toolSchemas[*]` so plugin authors can self-attest that a tool's pathFields stay inside the owning plugin sandbox.

## Context

Host (lvis-app PR #860 commit `20fcafb6`) already wires the field through the descriptor → adapter → reviewer pipeline:
- `extractDeclaredPaths` canonicalizes pathField values (path-traversal defense)
- `ownerPluginSandboxRoot` canonicalized at rule level (defense-in-depth)
- Sandbox-write auto-LOW rule grants LOW verdict when *all* declared paths resolve inside `~/.lvis/plugins/<pluginId>/`
- Fail-open: declaration of `true` with paths escaping sandbox falls back to standard write rules (no privilege escalation possible)

Without this SDK exposure, plugin authors couldn't discover the field from their typed manifest — host accepts it but TypeScript doesn't.

## Use case
`lvis-plugin-ms-graph` persists MSAL token cache to its own sandbox. Without this flag the host's `allowedDirectories` doesn't include plugin sandboxes (§5 file-based memory isolation), so the write would hit "write outside allowed dirs" HIGH and be deferred forever. Issue #664 P0 root cause.

## Test plan
- [x] TypeScript types compile
- [x] JSON schema (`schemas/plugin-manifest.schema.json`) accepts the optional boolean field
- [ ] Plugin manifest sanity test (if exists) — picks up new field as optional

Refs lvis-project/lvis-app#860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)