### PR TITLE
feat(manifest): notificationEvents[*].bypassFocusGate field (companion to lvis-app#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [5.9.0] - 2026-05-17
+
+### Added — `notificationEvents[*].bypassFocusGate` (optional boolean)
+
+플러그인 manifest 의 `notificationEvents[i]` 에 `bypassFocusGate?: boolean`
+필드 추가. host (lvis-app PR #875) 의 multi-window focus gate + cooldown
+gate 를 우회하는 *critical alert* opt-in. 예: meeting plugin 의
+`meeting.starting-soon` — 사용자 attention 이 다른 window 에 있어도
+정상 표시되어야 하는 알림.
+
+- **Schema**: `schemas/plugin-manifest.schema.json` 의
+  `notificationEvents.items.properties` 에 `bypassFocusGate: { type: "boolean" }`
+  추가. AJV strict (`additionalProperties: false`) 와 호환.
+- **Types**: `src/index.ts` 의 `PluginManifest.notificationEvents[i]` +
+  `PluginMarketplaceItem.notificationEvents[i]` 양쪽 모두 동일한 optional
+  field 노출 (marketplace 카드 표시 일관성).
+- **Host contract**: host 가 `bypassFocusGate=true` 이면 focus gate +
+  cooldown gate + (manifest 가 허용한 경우) urgent flag 까지 함께 적용.
+  기본값 `false` 또는 omitted — 기존 동작 그대로.
+- **Cross-repo ordering**: host package.json 의 `@lvis/plugin-sdk` dep 이
+  ≥5.9.0 으로 bump 되어야 manifest validation 통과. host PR #875 와 함께
+  publish 필요.
+
+---
+
 ## [5.8.0] - 2026-05-16
 
 ### Added — `runtime/network` shared DNS-probe primitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [5.9.0] - 2026-05-17
+## [5.9.2] - 2026-05-17
 
-### Added — `notificationEvents[*].bypassFocusGate` (optional boolean)
+> **Version slot note**: tags `v5.9.0` (df6bacc) and `v5.9.1` (0ccc887)
+> were cut on commits with stale `package.json` (still 5.8.0) before this
+> bump. Per the README "Tag policy" rule (immutable release points), we
+> skip those slots and ship as 5.9.2.
+
+### Added — `notificationEvents[*].bypassFocusGate` (optional boolean) [#151]
 
 플러그인 manifest 의 `notificationEvents[i]` 에 `bypassFocusGate?: boolean`
 필드 추가. host (lvis-app PR #875) 의 multi-window focus gate + cooldown
@@ -27,8 +32,16 @@ gate 를 우회하는 *critical alert* opt-in. 예: meeting plugin 의
   cooldown gate + (manifest 가 허용한 경우) urgent flag 까지 함께 적용.
   기본값 `false` 또는 omitted — 기존 동작 그대로.
 - **Cross-repo ordering**: host package.json 의 `@lvis/plugin-sdk` dep 이
-  ≥5.9.0 으로 bump 되어야 manifest validation 통과. host PR #875 와 함께
+  ≥5.9.2 으로 bump 되어야 manifest validation 통과. host PR #875 와 함께
   publish 필요.
+
+### Added — `toolSchemas[*].writesToOwnSandbox` (optional boolean) [#150]
+
+`toolSchemas[i]` 에 `writesToOwnSandbox?: boolean` 추가. plugin sandbox
+디렉토리 (`~/.lvis/plugins/<pluginId>/`) 내부 쓰기만 한다고 *self-attest*
+하면 host reviewer 가 LOW risk 로 routing — 매번 user prompt 안 띄움 (ms-graph
+MSAL token cache 등 OAuth flow). runtime 이 path containment 를 invocation
+시점에 verify — 실제 sandbox 밖이면 standard write rule 로 fallback.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "5.9.0",
+  "version": "5.9.2",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -391,6 +391,10 @@
           },
           "bodyField": {
             "type": "string"
+          },
+          "bypassFocusGate": {
+            "type": "boolean",
+            "description": "When true, this event bypasses the host focus-gate suppression and always fires an OS-level notification regardless of LVIS window focus state. Use for critical flows (meeting capture, security alerts) where the user must be notified out-of-band. Refs lvis-project/lvis-app#843."
           }
         }
       }

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -394,7 +394,7 @@
           },
           "bypassFocusGate": {
             "type": "boolean",
-            "description": "When true, this event bypasses the host focus-gate suppression and always fires an OS-level notification regardless of LVIS window focus state. Use for critical flows (meeting capture, security alerts) where the user must be notified out-of-band. Refs lvis-project/lvis-app#843."
+            "description": "When true, this event bypasses the host focus-gate AND cooldown-gate suppression and always fires an OS-level notification regardless of LVIS window focus state or recent prior emits from the same plugin. The host additionally promotes urgent=true for bypass events (sound + critical urgency) unless the caller explicitly opts out. Use for critical flows (meeting capture, security alerts) where the user must be notified out-of-band. Refs lvis-project/lvis-app#843."
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,14 @@ export interface PluginManifest {
     event: string;
     titleField?: string;
     bodyField?: string;
+    /**
+     * When `true`, this event bypasses the host focus-gate suppression and
+     * always fires an OS-level notification regardless of LVIS window focus.
+     * Use for critical flows (meeting capture, security alerts) where the
+     * user must be notified out-of-band. Refs lvis-project/lvis-app#843.
+     * @optional
+     */
+    bypassFocusGate?: boolean;
   }>;
   installPolicy?: InstallPolicy;
   dependencies?: Array<string | DependencySpec>;
@@ -473,6 +481,14 @@ export interface PluginMarketplaceItem {
     event: string;
     titleField?: string;
     bodyField?: string;
+    /**
+     * When `true`, this event bypasses the host focus-gate suppression and
+     * always fires an OS-level notification regardless of LVIS window focus.
+     * Use for critical flows (meeting capture, security alerts) where the
+     * user must be notified out-of-band. Refs lvis-project/lvis-app#843.
+     * @optional
+     */
+    bypassFocusGate?: boolean;
   }>;
   installPolicy?: InstallPolicy;
   dependencies?: Array<string | DependencySpec>;


### PR DESCRIPTION
## Summary

Companion SDK PR for lvis-project/lvis-app#875 — adds optional `bypassFocusGate` boolean to each `notificationEvents` entry.

Without this, AJV's `additionalProperties: false` on the items schema rejects any manifest carrying the new flag. Host (PR #875) accepts it but plugin authors couldn't declare it through the typed SDK.

## Changes

- `schemas/plugin-manifest.schema.json`: `notificationEvents.items.properties.bypassFocusGate: {type:boolean}` + description
- `src/index.ts` × 2 (PluginManifest + PluginMarketplaceItem): TypeScript type field + JSDoc

## Use case

Critical flows (meeting capture, security alerts) need OS notification regardless of LVIS window focus. Without bypass, the host focus-gate suppresses while user is in app — but the user should be notified out-of-band.

## Test plan
- [x] TypeScript types compile
- [x] JSON schema accepts the new optional boolean
- [ ] Companion host PR #875 vitest 33/33 passes (verified upstream)

Refs lvis-project/lvis-app#843 / #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)