### PR TITLE
feat: add allow-session to ApprovalChoice union (v5.12.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -807,8 +807,20 @@ export interface PluginHostApi {
   };
 }
 
+/**
+ * §8 ApprovalChoice — mirrors the host `approval-gate.ts` union.
+ *
+ * Plugin contract (REQUIRED):
+ *   - "allow-once" / "allow-session" are HOST-OWNED LIFETIMES. Plugins MUST
+ *     re-request through the host approval gate for each tool invocation;
+ *     caching either value inside the plugin process is a contract violation.
+ *   - Only "allow-always" may be remembered, and only if the host's
+ *     `rememberPattern` indicates a persisted rule (verified by host audit).
+ *   - "deny-once" / "deny-always" terminate the current tool call only.
+ */
 export type ApprovalChoice =
   | "allow-once"
+  | "allow-session"
   | "allow-always"
   | "deny-once"
   | "deny-always";


### PR DESCRIPTION
## Summary
- Adds `"allow-session"` to `ApprovalChoice` union — new in-conversation lifetime tier between `allow-once` (single tool call) and `allow-always` (persisted)
- Documents host-owned lifetime invariant in JSDoc so plugins do not silently cache grants
- Version bump 5.11.0 → 5.12.0 (additive type extension, non-breaking)

## Companion
**Lockstep with [`lvis-app#897`](https://github.com/lvis-project/lvis-app/pull/897)** (permission scope lifetime fix). This SDK PR must merge + tag `v5.12.0` **first** so the host PR can pin `@lvis/plugin-sdk@v5.12.0`.

## Supersedes
Previous PR #156 closed — rebased onto current main (which advanced to 5.11.0 via PRs #154/#893 while this branch was open).

## Context
User report: clicking "한 번만 허용" on the host's out-of-allowed-dir dialog re-prompted for the same directory on every subsequent tool call. Root cause + full fix in the host PR; the SDK change exposes the new lifetime literal to plugins that participate in the approval gate via `hostApi.agentApproval`.

## Plugin contract (new JSDoc)
- `allow-once` / `allow-session` are **host-owned lifetimes** — plugins MUST re-request approval per tool invocation
- Only `allow-always` may be remembered, and only if the host's `rememberPattern` indicates a persisted rule
- `deny-*` terminates the current tool call only

## Test plan
- [ ] `bun test` — SDK type-only tests
- [ ] After merge + tag v5.12.0: update host `package.json` pin and verify host build passes
- [ ] Verify plugin repos that import `ApprovalChoice` still build (no breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)