### PR TITLE
refactor(naming): strip H[N] hardening-pass labels from sync scripts

### DIFF
--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -1036,7 +1036,7 @@ function restrictMarketplaceChannelToStable(text) {
 }
 
 /**
- * H3 — host `types.ts` is missing the `python?` block that the host's
+ * Host `types.ts` is missing the `python?` block that the host's
  * JSON Schema (and pageindex's published `plugin.json`) already accept.
  * Inject it into `PluginManifest` so plugin authors get type-checking
  * parity with what the schema validates. Idempotent — skips when already

--- a/scripts/sync-schema-from-host.mjs
+++ b/scripts/sync-schema-from-host.mjs
@@ -129,7 +129,7 @@ function normalize(s) {
 }
 
 /**
- * H6 — cross-field invariant `auth.statusTool ∈ uiCallable[]` (and the
+ * Cross-field invariant `auth.statusTool ∈ uiCallable[]` (and the
  * matching `loginTool` / `logoutTool`) currently lives only in prose
  * under `properties.auth.description`. Inject a JSON Schema `allOf`
  * clause that lifts the *structural half* of the invariant — when


### PR DESCRIPTION
2 docstring sites (H3 / H6) in scripts/sync-from-host.mjs and scripts/sync-schema-from-host.mjs cleaned up per project-wide naming convention. No code-behavior change. Merge: hold.