### PR TITLE
refactor(naming): purge process-metadata tags

### DIFF
--- a/scripts/sync-from-host.mjs
+++ b/scripts/sync-from-host.mjs
@@ -1067,10 +1067,10 @@ function ensurePluginManifestPackageName(text) {
 }
 
 /**
- * Phase-1 schema-master sync — author + uiSlots TS surface.
+ * Schema-master sync — author + uiSlots TS surface.
  *
  * `author` (individual maintainer) lives in the SDK schema even though
- * the host's plugin.schema.json doesn't carry it after the Phase-1 prune.
+ * the host's plugin.schema.json doesn't carry it after the schema prune.
  * Plugin authors expect a credit field; `publisher` (organization) and
  * `author` (individual) are intentionally distinct. Inject on the SDK
  * side so manifest typings surface it.

--- a/scripts/sync-schema-from-host.mjs
+++ b/scripts/sync-schema-from-host.mjs
@@ -219,10 +219,10 @@ function tightenVersionPatternToStable(schema) {
 }
 
 /**
- * Phase-1 schema-master sync — author + uiSlots + bounded configSchema default.
+ * Schema-master sync — author + uiSlots + bounded configSchema default.
  *
  * The host's `plugin.schema.json` historically had a richer `author` field
- * (PR #404 era) that was lost during the Phase-1 prune. The host doesn't
+ * (PR #404 era) that was lost during the schema prune. The host doesn't
  * read it, but plugin authors expect to declare credit somewhere — keeping
  * it in the SDK schema so consumers (marketplace UI, IDE intellisense)
  * have a place to surface "made by". `publisher` (organization) and


### PR DESCRIPTION
## Summary

- Remove `Phase-1` milestone labels from JSDoc headings in both sync scripts
- Replace with domain descriptions of the schema sync operation; keep `PR #404 era` reference (issue-ref, permitted)
- Re-verify grep: 0 hits remaining

## Files changed
- `scripts/sync-from-host.mjs` — JSDoc heading + inline reference
- `scripts/sync-schema-from-host.mjs` — JSDoc heading + inline reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)