### PR TITLE
feat(schema): add optional requires.minAppVersion plugin↔app min-version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## v5.16.0 — 2026-06-22
+
+### Added
+- `requires.minAppVersion` — optional plain SemVer (`MAJOR.MINOR.PATCH`, **not** a range, Obsidian-style) declaring the lowest LVIS app version that can load this plugin. Lives in the manifest's existing `requires` block alongside `capabilities`. **Optional and purely additive**: a manifest without it stays compatible with every app version (no behavior change for existing plugins). The host enforces it at BOTH install (marketplace hard block before download) and load (skips `start()` and surfaces a non-dismissable "needs newer app" state on a too-old app). Schema validates the SemVer pattern (`>=1.2.3`, `1.2`, leading zeros, and non-strings are rejected).
+  - SDK ships only the JSON-schema acceptance for the field this release. The TypeScript `RequiresSpec.minAppVersion` mirror lands in `src/index.ts` via `sync-from-host` once the host `types.ts` (the SoT) carries the field; until then the schema is the authority and the host owns the compare/enforce logic.
+
+---
+
 ## v5.15.0 — 2026-06-22
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvis/plugin-sdk",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "private": false,
   "description": "SDK for authoring LVIS plugins. Type contracts (PluginManifest / PluginHostApi / PluginRuntimeContext / RuntimePlugin) re-exported from the host as a single source of truth, plus thin runtime utilities (UI primitives, build helpers, host-context shims for safeStorage / shell.openExternal) shared across plugin repos.",
   "type": "module",

--- a/schemas/plugin-manifest.schema.json
+++ b/schemas/plugin-manifest.schema.json
@@ -546,6 +546,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "minAppVersion": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "description": "Minimum LVIS app version (plain SemVer MAJOR.MINOR.PATCH, not a range) required to load this plugin. The host refuses to install (hard block before download) and refuses to activate (skips start(), surfaces a non-dismissable \"needs newer app\" state) when the running app is older. Omit for no minimum (compatible with all app versions)."
         }
       },
       "additionalProperties": false

--- a/scripts/sync-schema-from-host.mjs
+++ b/scripts/sync-schema-from-host.mjs
@@ -309,6 +309,36 @@ function ensureBoundedConfigSchemaDefault(schema) {
   return schema;
 }
 
+/**
+ * Plugin↔app minimum-version gate — `requires.minAppVersion`.
+ *
+ * Optional plain SemVer (MAJOR.MINOR.PATCH, NOT a range — Obsidian-style)
+ * declaring the lowest LVIS app version that can load this plugin. The host
+ * enforces it at BOTH install (marketplace.ts hard block before download)
+ * and load (runtime/index.ts skips start() on a too-old app); absent =
+ * compatible with every app version (backward-compat, purely additive).
+ *
+ * Lives in the SDK-side post-process layer (alongside `author` / `uiSlots`)
+ * until the host's `plugin.schema.json` carries the field in its own
+ * `requires` block. Once the host schema gains `minAppVersion`, this
+ * injector becomes a no-op (the idempotent guard below) and can be retired
+ * in the same pass that retires the host-lagging author/uiSlots injectors.
+ */
+function ensureRequiresMinAppVersion(schema) {
+  const requires = schema.properties?.requires;
+  if (!requires || requires.type !== "object") return schema;
+  if (!requires.properties) requires.properties = {};
+  if (!requires.properties.minAppVersion) {
+    requires.properties.minAppVersion = {
+      type: "string",
+      pattern: "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+      description:
+        "Minimum LVIS app version (plain SemVer MAJOR.MINOR.PATCH, not a range) required to load this plugin. The host refuses to install (hard block before download) and refuses to activate (skips start(), surfaces a non-dismissable \"needs newer app\" state) when the running app is older. Omit for no minimum (compatible with all app versions).",
+    };
+  }
+  return schema;
+}
+
 function postProcessSdkSchema(text) {
   const obj = JSON.parse(text);
   tightenVersionPatternToStable(obj);
@@ -317,6 +347,7 @@ function postProcessSdkSchema(text) {
   ensurePluginManifestAuthor(obj);
   ensurePluginManifestUiSlots(obj);
   ensureBoundedConfigSchemaDefault(obj);
+  ensureRequiresMinAppVersion(obj);
   return JSON.stringify(obj, null, 2) + "\n";
 }
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -86,6 +86,84 @@ describe("PluginManifest — schema validation", () => {
     expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
   });
 
+  // Plugin↔app minimum-version gate — `requires.minAppVersion`.
+  // The field is authored in the manifest's `requires` block (alongside
+  // `capabilities`) as a plain SemVer string. It is optional and purely
+  // additive: a manifest without it MUST keep validating (backward-compat).
+  // NOTE: the SDK's generated `RequiresSpec` type (src/index.ts) does not
+  // yet carry `minAppVersion` — it lands there via `sync-from-host` once the
+  // host's types.ts (SoT) gains the field. So these fixtures are authored as
+  // plain objects (no PluginManifest annotation) to exercise the SCHEMA,
+  // which is the artifact this phase ships.
+  describe("requires.minAppVersion — minimum-version gate", () => {
+    it("accepts a manifest WITHOUT minAppVersion (backward-compat — no minimum)", () => {
+      const noGate = {
+        ...VALID_MINIMAL,
+        requires: { capabilities: ["calendar"] },
+      };
+      const { valid, errors } = validateManifest(noGate);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+
+    it("accepts a manifest with a valid SemVer minAppVersion", () => {
+      const gated = {
+        ...VALID_MINIMAL,
+        requires: { capabilities: [], minAppVersion: "1.2.3" },
+      };
+      const { valid, errors } = validateManifest(gated);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+
+    it("accepts minAppVersion as the sole field of requires (capabilities optional in schema)", () => {
+      const gatedOnly = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: "0.2.13" },
+      };
+      const { valid, errors } = validateManifest(gatedOnly);
+      expect(valid, `Errors: ${errors.join(", ")}`).toBe(true);
+    });
+
+    it("rejects a non-SemVer minAppVersion (range syntax)", () => {
+      const ranged = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: ">=1.2.3" },
+      };
+      expect(validateManifest(ranged).valid).toBe(false);
+    });
+
+    it("rejects a non-SemVer minAppVersion (MAJOR.MINOR only)", () => {
+      const partial = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: "1.2" },
+      };
+      expect(validateManifest(partial).valid).toBe(false);
+    });
+
+    it("rejects a non-SemVer minAppVersion (leading zero)", () => {
+      const leadingZero = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: "1.02.3" },
+      };
+      expect(validateManifest(leadingZero).valid).toBe(false);
+    });
+
+    it("rejects a non-SemVer minAppVersion (non-numeric)", () => {
+      const bogus = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: "latest" },
+      };
+      expect(validateManifest(bogus).valid).toBe(false);
+    });
+
+    it("rejects a non-string minAppVersion", () => {
+      const numeric = {
+        ...VALID_MINIMAL,
+        requires: { minAppVersion: 1.2 },
+      };
+      expect(validateManifest(numeric).valid).toBe(false);
+    });
+  });
+
   it("treats toolSchemas[*].category as optional and deprecated (host classifies risk)", () => {
     // A category-bearing toolSchema still validates (backward compatibility).
     const withCategory: PluginManifest = {


### PR DESCRIPTION
## Summary

Adds the **SDK side** of the plugin↔app minimum-version gate: an optional plain-SemVer `requires.minAppVersion` field on the plugin manifest. Obsidian-style — a plain `MAJOR.MINOR.PATCH`, **not** a range.

- **Optional + additive**: a manifest without it stays compatible with every app version. No existing plugin breaks.
- Authored inside the existing `requires` block, alongside `capabilities` — reuses the existing `requires` plumbing.
- Declares the lowest LVIS app version that can load the plugin. The **host** enforces it at BOTH gates (install: hard block before artifact download; load: skip `start()`, surface a non-dismissable "needs newer app" state). Host enforcement + types + marketplace land in their own phases; this PR ships only the schema acceptance for the field.

## Changes

| File | Change |
|------|--------|
| `schemas/plugin-manifest.schema.json` | `minAppVersion` under `requires` — strict `^(0\|[1-9][0-9]*)\.(...)...$` SemVer pattern (no leading zeros, no ranges) |
| `scripts/sync-schema-from-host.mjs` | `ensureRequiresMinAppVersion` post-process injector (idempotent), the SDK's established mechanism for fields the host schema hasn't adopted yet (cf. `author`/`uiSlots`) |
| `src/__tests__/index.test.ts` | accept (valid SemVer, absent, sole-field) + reject (range `>=1.2.3`, `1.2`, leading-zero, non-numeric, non-string) |
| `CHANGELOG.md` + `package.json` | minor bump 5.15.0 → 5.16.0 |

## Drift handling (deliberate)

`src/index.ts` (the **generated** `RequiresSpec` TS mirror) is **intentionally not edited**. It is auto-generated from the host `types.ts` SoT via `sync-from-host`; hand-editing it would fail `drift-check.yml` idempotency. The `minAppVersion` TS field lands in the mirror automatically once the host `types.ts` carries it (host-enforcement phase). This PR touches no `drift-check.yml` path (`src/index.ts` / tokens), so that workflow does not run here; `check:dist-drift` passes (no `src/` runtime change).

## Verification

- `bun run test` — 457 passed (14 files), incl. 8 new minAppVersion cases
- `bunx tsc --noEmit` — clean
- `bun run build` — success
- `bun run check:dist-drift` — dist up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)